### PR TITLE
Fire off tasks for branches and releases

### DIFF
--- a/api/taskUpdate.js
+++ b/api/taskUpdate.js
@@ -10,6 +10,12 @@ async function handle(req, res, serverConf, redisClient) {
     return
   }
   const taskDetails = await redisClient.fetch('stampede-' + req.body.external_id)
+  if (taskDetails.pullRequest == null) {
+    console.log('--- Not a PR update, skipping')
+    res.send({status: 'ok'})
+    return
+  }
+
   const owner = taskDetails.owner
   const repository = taskDetails.repository
   const buildNumber = taskDetails.buildNumber


### PR DESCRIPTION
This PR adds in the logic to fire off tasks for branch pushes and release publishing. The repo has to be configured for it, similar to how Pull Requests are.

Note that for branches, the specific named branch is configured, we don't support wildcards yet. For releases we always run the same tasks on them.