### PR TITLE
Active build and task tracking in cache working

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 David House
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/events/checkRun.js
+++ b/events/checkRun.js
@@ -28,6 +28,9 @@ async function handle(req, serverConf, cache) {
         event.pullRequests[index], event.cloneURL,
         octokit, cache)
     }
+  } else {
+    console.log('--- ignoring check run, not a rerequested one')
+    return {status: 'check run ignored as it was not a rerequested check'}
   }
   return {status: 'check runs created'}
 }

--- a/events/push.js
+++ b/events/push.js
@@ -86,10 +86,12 @@ async function handle(req, serverConf, cache) {
             id: task.id,
           },
           status: 'queued',
+          buildID: buildPath + '-' + buildNumber,
           external_id: external_id,
           clone_url: event.cloneURL,
         }
         console.log(chalk.green('--- Creating task: ' + task.id))
+        await cache.addTaskToActiveList(buildPath + '-' + buildNumber, task.id)
         const queue = taskQueue.createTaskQueue('stampede-' + task.id)
         queue.add(taskDetails)
         // TODO: Send out notification of queued task

--- a/events/release.js
+++ b/events/release.js
@@ -114,12 +114,15 @@ async function handle(req, serverConf, cache) {
         id: task.id,
       },
       status: 'queued',
+      buildID: buildPath + '-' + buildNumber,
       external_id: external_id,
       clone_url: event.cloneURL,
     }
     console.log(chalk.green('--- Creating task: ' + task.id))
+    await cache.addTaskToActiveList(buildPath + '-' + buildNumber, task.id)
     const queue = taskQueue.createTaskQueue('stampede-' + task.id)
     queue.add(taskDetails)
+    // TODO: notification
   }
   return {status: 'tasks created for the release'}
 }

--- a/lib/checkRun.js
+++ b/lib/checkRun.js
@@ -73,7 +73,7 @@ async function createCheckRun(owner, repo, sha, pullRequest, cloneURL, octokit, 
       status: 'queued',
       external_id: external_id,
       started_at: started_at,
-    })  
+    })
 
     // store the initial task details
     const taskDetails = {
@@ -87,11 +87,13 @@ async function createCheckRun(owner, repo, sha, pullRequest, cloneURL, octokit, 
       },
       status: 'queued',
       external_id: external_id,
+      buildID: buildPath + '-' + buildNumber,
       clone_url: cloneURL,
       started_at: started_at,
-      checkRunID: checkRun.id,
+      checkRunID: checkRun.data.id,
     }
     console.log(chalk.green('--- Creating task: ' + task.id))
+    await cache.addTaskToActiveList(buildPath + '-' + buildNumber, task.id)
     // TODO: Queue the task here and send out the notification
     console.log(chalk.green('--- Adding task to queue: ' + taskDetails.task.id))
     const queue = taskQueue.createTaskQueue('stampede-' + taskDetails.task.id)

--- a/lib/taskUpdate.js
+++ b/lib/taskUpdate.js
@@ -13,10 +13,20 @@ async function handle(job, serverConf, cache) {
   const event = job.data
   console.dir(event)
 
-  // TODO: Remove task from active task list
-  // TODO: Check for completed build also
-  // TODO: Send out some notifications on the above
+  // Update task in the cache and send out notifications
+  if (event.status === 'completed') {
+    await cache.removeTaskFromActiveList(event.buildID, event.task.id)
+    const remainingTasks = await cache.fetchActiveTasks(event.buildID)
+    if (remainingTasks == null || remainingTasks.length === 0) {
+      await cache.removeBuildFromActiveList(event.buildID)
+      // TODO: Notification of build finished
+    }
+    // TODO: notification of task finished
+  } else {
+    // TODO: Notification of task update
+  }
 
+  // If this update isn't for a PR check, then the rest of the flow is meaningless
   if (event.checkRunID == null) {
     console.log('--- skipping since it is not a check update')
     return

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stampede-server",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A distributed github task system",
   "main": "bin/stampede-server.js",
   "scripts": {
@@ -24,7 +24,7 @@
     "figlet": "^1.2.1",
     "morgan": "^1.9.1",
     "rc": "^1.2.8",
-    "stampede-cache": "^0.1.0"
+    "stampede-cache": "^0.2.0"
   },
   "devDependencies": {
     "eslint": "^6.3.0",


### PR DESCRIPTION
This PR updates the server so that it will track builds and tasks correctly. A build is added to the active builds list once it is created, and it is removed when all its active tasks are completed. A task is added to the builds active list, then removed from the list when it is completed.
