### PR TITLE
✨ Allow for setting GitHub app PEM directly from env

### DIFF
--- a/.stampede.yaml
+++ b/.stampede.yaml
@@ -1,0 +1,14 @@
+pullrequests:
+  tasks:
+    - id: pr-standards
+      config:
+        prMilestoneCheck: true
+    - id: lint-nodejs
+    - id: unit-tests-nodejs
+releases:
+  draft:
+    tasks:
+      - id: release-notes
+  published:
+    tasks:
+      - id: npm-publish

--- a/bin/stampede-server.js
+++ b/bin/stampede-server.js
@@ -5,6 +5,7 @@ const clear = require('clear')
 const figlet = require('figlet')
 const fs = require('fs')
 const cache = require('stampede-cache')
+const os = require('os')
 
 // Internal modules
 const web = require('../lib/web')
@@ -39,8 +40,22 @@ console.log(chalk.red('GitHub PEM Path: ' + conf.githubAppPEMPath))
 
 // Load up our key for this GitHub app. You get this key from GitHub
 // when you create the app.
-const pem = fs.readFileSync(conf.githubAppPEMPath, 'utf8')
-conf.githubAppPEM = pem
+if (conf.githubAppPEM == null) {
+  if (conf.githubAppPEMPath != null) {
+    const pem = fs.readFileSync(conf.githubAppPEMPath, 'utf8')
+    conf.githubAppPEM = pem
+  }
+} else {
+  conf.githubAppPEM = conf.githubAppPEM.replace(/\\n/g, os.EOL)
+}
+
+// Do some validation of config since we can't operate without our required
+// config
+console.log(conf.githubAppPEM)
+if (conf.githubAppID === 0 || conf.githubAppPEM == null || conf.githubHost == null) {
+  console.log(chalk.red('Stampede needs a GitHub APP ID, PEM certificate and host in order to operate. Not found in the config so unable to continue.'))
+  process.exit(1)
+}
 
 // Initialize our cache
 cache.startCache(conf)


### PR DESCRIPTION
This PR makes a change to how the PEM file is loaded. Previously, you set the `githubAppPEMPath` and the server would load the PEM from the file into the config. But in some cases you might want to set the config value for `githubAppPEM` directly, say from the environment for example. This is now possible to do. Setting `githubAppPEM` directly will cause `githubAppPEMPath` to be ignored.

Also added a more friendly error message if any of the GitHub required config is missing.