### PR TITLE
🐛 If a check update fails, try removing the output and try again

### DIFF
--- a/lib/taskUpdate.js
+++ b/lib/taskUpdate.js
@@ -54,6 +54,12 @@ async function handle(job, serverConf, cache) {
   console.log('--- updating check')
   await octokit.checks.update(update).catch((error) => {
     console.log(chalk.red('Error updating check in Github: ' + error))
+    update.output = {
+      title: 'Task Results',
+      summary: 'Error applying task results, contact your stampede admin.',
+      text: '',
+    }
+    octokit.checks.update(update)
   })
 }
 


### PR DESCRIPTION
This PR adds an second update attempt when updating a task check with a simpler output block just in the attempt to update the task so it will show complete.