### PR TITLE
♻️💥 Split task config loading into several files

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -11,14 +11,32 @@ const chalk = require('chalk')
 async function initialize(conf, cache) {
   // If we have a local path, attempt to initialize our config from there
   if (conf.stampedeConfigPath != null) {
-    if (fs.existsSync(conf.stampedeConfigPath + '/tasks.yaml')) {
-      const tasks = yaml.safeLoad(fs.readFileSync(conf.stampedeConfigPath +
-                                '/tasks.yaml'))
-      cache.storeTaskConfig(tasks)
-      console.log(chalk.green('--- Saved task list from tasks.yaml'))
-    } else {
-      cache.storeTaskConfig([])
+    await cache.removeTaskConfig()
+    const tasksPath = conf.stampedeConfigPath + '/tasks'
+    if (fs.existsSync(tasksPath)) {
+      const files = fs.readdirSync(tasksPath).filter(function(file) {
+        return file.endsWith('.yaml')
+      })
+      for (let index = 0; index < files.length; index++) {
+        const taskDetails = yaml.safeLoad(fs.readFileSync(conf.stampedeConfigPath +
+                                '/tasks/' + files[index]))
+        if (taskDetails.id != null) {
+          await cache.storeTask(taskDetails.id)
+          await cache.storeTaskConfig(taskDetails.id, taskDetails)
+        } else {
+          console.log(chalk.red('Skipping ' + files[index] + ' as no task id found'))
+        }
+      }
     }
+
+    // if (fs.existsSync(conf.stampedeConfigPath + '/tasks.yaml')) {
+    //   const tasks = yaml.safeLoad(fs.readFileSync(conf.stampedeConfigPath +
+    //                             '/tasks.yaml'))
+    //   cache.storeTaskConfig(tasks)
+    //   console.log(chalk.green('--- Saved task list from tasks.yaml'))
+    // } else {
+    //   cache.storeTaskConfig([])
+    // }
 
     if (fs.existsSync(conf.stampedeConfigPath + '/defaults.yaml')) {
       const defaults = yaml.safeLoad(fs.readFileSync(conf.stampedeConfigPath +

--- a/package-lock.json
+++ b/package-lock.json
@@ -2071,9 +2071,9 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "stampede-cache": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/stampede-cache/-/stampede-cache-0.4.0.tgz",
-      "integrity": "sha512-Ck6ZyY9FxvIqqYSohDUt1j0vltodJNgcyl8XTPShNExYGGTl/CXae20xHYOATRfiOEUEn9Xz/Z3dEIMz/IrYFg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/stampede-cache/-/stampede-cache-0.5.0.tgz",
+      "integrity": "sha512-gW6rovFpkx9WI8YjvpFYGWySBmZvkjXiqy/Q1Ktt3T/CQx7OETmhFwKG08sfLp3Hpcwe5xhvDrEFdnqImiB9AQ==",
       "requires": {
         "async-redis": "1.1.7"
       }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lynn-request": "^0.4.6",
     "morgan": "^1.9.1",
     "rc": "^1.2.8",
-    "stampede-cache": "^0.4.0"
+    "stampede-cache": "^0.5.0"
   },
   "devDependencies": {
     "eslint": "^6.3.0",


### PR DESCRIPTION
This PR changes how the `tasks.yaml` is loaded. Instead of a single file, a folder named `tasks` is now expected and should contain one file per `task` that the system will allow. So far this PR just expects the information to be separated. Eventually this will lead to further details going into the task config files.