### PR TITLE
✨ added completedAt time for tasks

### DIFF
--- a/lib/taskUpdate.js
+++ b/lib/taskUpdate.js
@@ -21,6 +21,7 @@ async function handle(job, serverConf, cache, scm) {
 
     // Update task in the cache and send out notifications
     if (event.status === 'completed') {
+      event.stats.completedAt = new Date()
       // Remove this task from the active list
       await cache.removeTaskFromActiveList(event.buildID, taskID)
       await notification.taskCompleted(taskID, event)


### PR DESCRIPTION
This PR adds a `completedAt` timestamp to the task details before task completed notification is sent out. This represents the full lifecycle of the task execution and can be compared to the `queuedTime` to calculate the full duration. Do not compare to `startedAt` or `finishedAt` since those are captured from the worker which may have a different time clock offset.

Closes #69 