### PR TITLE
✨ Now supports pull request edit

### DIFF
--- a/events/pullRequest.js
+++ b/events/pullRequest.js
@@ -1,7 +1,11 @@
 'use strict'
 
+const chalk = require('chalk')
+
 const checkRun = require('../lib/checkRun')
 const notification = require('../lib/notification')
+const config = require('../lib/config')
+const build = require('../lib/build')
 
 /**
  * handle event
@@ -22,6 +26,9 @@ async function handle(req, serverConf, cache, scm) {
       event.pullRequest, event.cloneURL, event.sshURL,
       scm, cache, serverConf)
     return {status: 'pull request tasks created'}
+  } else if (event.action === 'edited') {
+    await pullRequestEdit(event.owner, event.repo, event.sha, event.pullRequest,
+      event.cloneURL, event.sshURL, scm, cache, serverConf)
   } else {
     return {status: 'ignored, pull request not opened or reopened'}
   }
@@ -46,6 +53,62 @@ function parseEvent(req) {
     cloneURL: req.body.repository.clone_url,
     sshURL: req.body.repository.ssh_url,
   }
+}
+
+/**
+ * Create a check run
+ * @param {*} owner
+ * @param {*} repo
+ * @param {*} sha
+ * @param {*} pullRequest
+ * @param {*} cloneURL
+ * @param {*} sshURL
+ * @param {*} scm
+ * @param {*} cache
+ * @param {*} serverConf
+ */
+async function pullRequestEdit(owner, repo, sha, pullRequest, cloneURL, sshURL,
+  scm, cache, serverConf) {
+  console.log(chalk.green('--- Creating check run for ' + owner + ' ' +
+                          repo + ' PR ' + pullRequest.number))
+
+  const repoConfig = await config.findRepoConfig(owner, repo, sha, serverConf.stampedeFileName,
+    scm, cache, serverConf)
+  console.dir(repoConfig)
+  if (repoConfig == null) {
+    console.log(chalk.red('--- Unable to determine config, no found in Redis or the project. Unable to continue'))
+    return
+  }
+
+  if (repoConfig.pullrequestedit == null || repoConfig.pullrequestedit.tasks == null) {
+    console.log(chalk.red('--- Unable to find tasks. Unable to continue.'))
+    return
+  }
+
+  console.dir(repoConfig.pullrequestedit)
+  console.dir(repoConfig.pullrequestedit.tasks)
+  if (repoConfig.pullrequestedit.tasks.length === 0) {
+    console.log(chalk.red('--- Task list was empty. Unable to continue.'))
+    return
+  }
+
+  const buildDetails = {
+    owner: owner,
+    repo: repo,
+    sha: sha,
+    pullRequest: pullRequest,
+    buildKey: 'pullrequest-' + pullRequest.number,
+  }
+
+  const scmDetails = {
+    id: serverConf.scm,
+    cloneURL: cloneURL,
+    sshURL: sshURL,
+    pullRequest: pullRequest,
+  }
+
+  build.startBuild(buildDetails, scm, scmDetails, repoConfig, repoConfig.pullrequestedit,
+    repoConfig.pullrequestedit.tasks, cache, serverConf)
 }
 
 module.exports.handle = handle


### PR DESCRIPTION
This PR allows the server to support pull request edits to trigger a build. Will need to experiment more with this as I'm not sure its exactly how I want to implement it, but this should work. To use this, add a `pullrequestedit` section to the `.stampede.yaml`. 

Closes #57 