### PR TITLE
✨ Simplified pull request details in messages

### DIFF
--- a/events/pullRequest.js
+++ b/events/pullRequest.js
@@ -92,11 +92,24 @@ async function pullRequestEdit(owner, repo, sha, pullRequest, cloneURL, sshURL,
     return
   }
 
+  const pullRequestDetails = {
+    number: pullRequest.number,
+    title: pullRequest.title,
+    head: {
+      ref: pullRequest.head.ref,
+      sha: pullRequest.head.sha,
+    },
+    base: {
+      ref: pullRequest.base.ref,
+      sha: pullRequest.base.sha,
+    },
+  }
+
   const buildDetails = {
     owner: owner,
     repo: repo,
     sha: sha,
-    pullRequest: pullRequest,
+    pullRequest: pullRequestDetails,
     buildKey: 'pullrequest-' + pullRequest.number,
   }
 
@@ -104,7 +117,7 @@ async function pullRequestEdit(owner, repo, sha, pullRequest, cloneURL, sshURL,
     id: serverConf.scm,
     cloneURL: cloneURL,
     sshURL: sshURL,
-    pullRequest: pullRequest,
+    pullRequest: pullRequestDetails,
   }
 
   build.startBuild(buildDetails, scm, scmDetails, repoConfig, repoConfig.pullrequestedit,

--- a/lib/checkRun.js
+++ b/lib/checkRun.js
@@ -42,11 +42,24 @@ async function createCheckRun(owner, repo, sha, pullRequest, cloneURL, sshURL,
     return
   }
 
+  const pullRequestDetails = {
+    number: pullRequest.number,
+    title: pullRequest.title,
+    head: {
+      ref: pullRequest.head.ref,
+      sha: pullRequest.head.sha,
+    },
+    base: {
+      ref: pullRequest.base.ref,
+      sha: pullRequest.base.sha,
+    },
+  }
+
   const buildDetails = {
     owner: owner,
     repo: repo,
     sha: sha,
-    pullRequest: pullRequest,
+    pullRequest: pullRequestDetails,
     buildKey: 'pullrequest-' + pullRequest.number,
   }
 
@@ -54,7 +67,7 @@ async function createCheckRun(owner, repo, sha, pullRequest, cloneURL, sshURL,
     id: serverConf.scm,
     cloneURL: cloneURL,
     sshURL: sshURL,
-    pullRequest: pullRequest,
+    pullRequest: pullRequestDetails,
   }
 
   build.startBuild(buildDetails, scm, scmDetails, repoConfig, repoConfig.pullrequests,


### PR DESCRIPTION
This PR reduces the information sent to the worker & notifications when an event based on a pull request is handled. Instead of sending the entire pull request GH payload, the server now only sends the information that is used by workers or other components.

Closes #75 