### PR TITLE
🐛Fixed an issue when pushing a new commit to a pull request

### DIFF
--- a/lib/checkRun.js
+++ b/lib/checkRun.js
@@ -47,7 +47,7 @@ async function createCheckRun(owner, repo, sha, pullRequest, cloneURL, sshURL,
     title: pullRequest.title,
     head: {
       ref: pullRequest.head.ref,
-      sha: sha, 
+      sha: sha,
     },
     base: {
       ref: pullRequest.base.ref,


### PR DESCRIPTION
We get a sha from GitHub events that might be different from the pull_request object head sha. This is probably a timing issue, but either way we should be using that sha as it should always be more correct than the pull request.

Closes #78 