### PR TITLE
✨ Added taskQueue option to task definition

### DIFF
--- a/lib/task.js
+++ b/lib/task.js
@@ -76,8 +76,9 @@ async function queuePendingTask(task, scm, cache, serverConf) {
   await cache.addTaskToActiveList(task.buildID, task.taskID)
   console.log(chalk.green('--- added task to active list: ' + task.buildID))
   notification.taskStarted(task.taskID, taskDetails)
-  console.log(chalk.green('--- Adding task to queue: ' + taskDetails.task.id))
-  const queue = taskQueue.createTaskQueue('stampede-' + taskDetails.task.id)
+  const queueName = await taskDetail.taskQueue(taskDetails.task.id, cache)
+  console.log(chalk.green('--- Adding task to queue: ' + queueName))
+  const queue = taskQueue.createTaskQueue('stampede-' + queueName)
   await queue.add(taskDetails)
   await queue.close()
 }
@@ -165,8 +166,9 @@ async function startTask(owner, repo, buildKey, sha, task, taskNumber, buildPath
   console.log(chalk.green('--- Creating task: ' + taskID))
   await cache.addTaskToActiveList(buildPath + '-' + buildNumber, taskID)
   await notification.taskStarted(taskID, taskDetails)
-  console.log(chalk.green('--- Adding task to queue: ' + taskDetails.task.id))
-  const queue = taskQueue.createTaskQueue('stampede-' + taskDetails.task.id)
+  const queueName = await taskDetail.taskQueue(taskDetails.task.id, cache)
+  console.log(chalk.green('--- Adding task to queue: ' + queueName))
+  const queue = taskQueue.createTaskQueue('stampede-' + queueName)
   await queue.add(taskDetails)
   await queue.close()
 }

--- a/lib/taskDetail.js
+++ b/lib/taskDetail.js
@@ -71,5 +71,23 @@ async function taskConfig(taskID, repoConfig, buildConfig, taskConfig, cache) {
   return config
 }
 
+/**
+ * taskQueue
+ * @param {*} taskID
+ * @param {*} cache
+ */
+async function taskQueue(taskID, cache) {
+  console.log('--- taskQueue:')
+  const globalTasksConfig = await cache.fetchTaskConfig(taskID)
+  console.log(globalTasksConfig.taskQueue)
+  if (globalTasksConfig == null) {
+    return taskID
+  }
+  return globalTasksConfig.taskQueue != null ?
+    globalTasksConfig.taskQueue :
+    taskID
+}
+
 module.exports.taskTitle = taskTitle
 module.exports.taskConfig = taskConfig
+module.exports.taskQueue = taskQueue


### PR DESCRIPTION
This PR adds a `taskQueue` option to the task definition. This is an optional property that if set will cause requests for this task to go into the specified queue. The default if not present is to use the task id as the queue.

Note: A new version of the worker will be required to handle this. Currently the worker is setup to only allow for processing a single task per worker. With a custom `taskQueue`, you can put multiple tasks into a single queue. The worker will be updated to handle this.