### PR TITLE
♻️ Move build number calculation to the org/repo level

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -21,7 +21,7 @@ async function startBuild(buildDetails, scm, scmDetails, repoConfig, buildConfig
   console.log(chalk.green('--- Build path: ' + buildDetails.buildPath))
 
   // determine our build number
-  const buildNumber = await cache.incrementBuildNumber(buildDetails.buildPath)
+  const buildNumber = await cache.incrementBuildNumber(buildDetails.owner + '-' + buildDetails.repo + '-buildNumber')
   buildDetails.buildNumber = buildNumber
   console.log(chalk.green('--- Created build number: ' + buildDetails.buildNumber))
 


### PR DESCRIPTION
This PR moves the build number calculation to the org/repo level. So different types of builds will share the same place to get a new build number. This means that PR builds will not start at build #1. But every build will be guaranteed a unique build number under that repo.

Closes #95