### PR TITLE
🐎 Updated stampede to execute release notes task

### DIFF
--- a/.stampede.yaml
+++ b/.stampede.yaml
@@ -6,9 +6,7 @@ pullrequests:
     - id: lint-nodejs
     - id: unit-tests-nodejs
 releases:
-  draft:
-    tasks:
-      - id: release-notes
   published:
     tasks:
       - id: npm-publish
+      - id: release-notes


### PR DESCRIPTION
This PR fixes the stampede file to make sure release notes gets executed on the release event.