### PR TITLE
🐛 Fixed issue with invalid task

### DIFF
--- a/bin/stampede-server.js
+++ b/bin/stampede-server.js
@@ -130,7 +130,6 @@ heartbeatQueue.on("error", function(error) {
 });
 
 heartbeatQueue.process(function(heartbeat) {
-  console.dir(heartbeat.data);
   cache.storeWorkerHeartbeat(heartbeat.data);
   notification.workerHeartbeat(heartbeat.data);
 });

--- a/lib/task.js
+++ b/lib/task.js
@@ -1,9 +1,9 @@
-'use strict';
+"use strict";
 
-const chalk = require('chalk');
-const taskDetail = require('./taskDetail');
-const notification = require('./notification');
-const taskQueue = require('./taskQueue');
+const chalk = require("chalk");
+const taskDetail = require("./taskDetail");
+const notification = require("./notification");
+const taskQueue = require("./taskQueue");
 
 /**
  * startTasks
@@ -69,14 +69,14 @@ async function startTasks(
   }
   // Setup any pending build onComplete tasks
   if (buildConfig.onCompleted != null) {
-    console.log('--- adding onCompleted tasks to pending list');
+    console.log("--- adding onCompleted tasks to pending list");
     for (let index = 0; index < tasks.length; index++) {
       const task = buildConfig.onCompleted[index];
       await addTaskToPending(
         owner,
         repo,
         buildKey,
-        buildPath + '-' + buildNumber + '-pending',
+        buildPath + "-" + buildNumber + "-pending",
         task,
         (tasks.length + index).toString(),
         buildPath,
@@ -108,9 +108,14 @@ async function addTaskToActiveList(
   taskNumber,
   cache
 ) {
+  const isValid = await taskDetail.isValidTask(task.id, cache);
+  if (isValid == false) {
+    return;
+  }
+
   const taskID =
-    buildPath + '-' + buildNumber + '-' + task.id + '-' + taskNumber.toString();
-  await cache.addTaskToActiveList(buildPath + '-' + buildNumber, taskID);
+    buildPath + "-" + buildNumber + "-" + task.id + "-" + taskNumber.toString();
+  await cache.addTaskToActiveList(buildPath + "-" + buildNumber, taskID);
 }
 
 /**
@@ -121,7 +126,7 @@ async function addTaskToActiveList(
  * @param {*} serverConf
  */
 async function queuePendingTask(task, scm, cache, serverConf) {
-  console.log(chalk.green('--- starting pending task: ' + task.taskID));
+  console.log(chalk.green("--- starting pending task: " + task.taskID));
   const taskTitle = await taskDetail.taskTitle(task.task.id, task.task, cache);
   const started_at = new Date();
   const taskDetails = task;
@@ -145,16 +150,16 @@ async function queuePendingTask(task, scm, cache, serverConf) {
     queuedAt: started_at
   };
 
-  console.log(chalk.green('--- Creating task: ' + task.taskID));
-  console.log(chalk.green('--- added task to active list: ' + task.buildID));
+  console.log(chalk.green("--- Creating task: " + task.taskID));
+  console.log(chalk.green("--- added task to active list: " + task.buildID));
   notification.taskStarted(task.taskID, taskDetails);
   const queueName = await taskDetail.taskQueue(
     taskDetails.task.id,
     cache,
     serverConf
   );
-  console.log(chalk.green('--- Adding task to queue: ' + queueName));
-  const queue = taskQueue.createTaskQueue('stampede-' + queueName);
+  console.log(chalk.green("--- Adding task to queue: " + queueName));
+  const queue = taskQueue.createTaskQueue("stampede-" + queueName);
   await queue.add(taskDetails, { removeOnComplete: true, removeOnFail: true });
   await queue.close();
 }
@@ -191,10 +196,15 @@ async function startTask(
   buildConfig,
   serverConf
 ) {
+  const isValid = await taskDetail.isValidTask(task.id, cache);
+  if (isValid == false) {
+    return;
+  }
+
   const taskID =
-    buildPath + '-' + buildNumber + '-' + task.id + '-' + taskNumber.toString();
-  console.log(chalk.green('--- starting task: ' + taskID));
-  console.log('repoConfig:');
+    buildPath + "-" + buildNumber + "-" + task.id + "-" + taskNumber.toString();
+  console.log(chalk.green("--- starting task: " + taskID));
+  console.log("repoConfig:");
   console.dir(repoConfig);
   const taskTitle = await taskDetail.taskTitle(task.id, task, cache);
   const taskConfig = await taskDetail.taskConfig(
@@ -226,9 +236,9 @@ async function startTask(
     repository: repo,
     buildKey: buildKey,
     buildNumber: buildNumber,
-    buildID: buildPath + '-' + buildNumber,
+    buildID: buildPath + "-" + buildNumber,
     taskID: taskID,
-    status: 'queued',
+    status: "queued",
     task: {
       id: task.id,
       number: taskNumber
@@ -240,7 +250,7 @@ async function startTask(
     }
   };
 
-  console.log('--- checking for onSuccess tasks');
+  console.log("--- checking for onSuccess tasks");
   console.dir(task.onSuccess);
   if (task.onSuccess != null) {
     for (
@@ -249,25 +259,31 @@ async function startTask(
       successIndex++
     ) {
       console.log(
-        '--- saving onSuccess task: ' + task.onSuccess[successIndex].id
+        "--- saving onSuccess task: " + task.onSuccess[successIndex].id
       );
-      await addTaskToPending(
-        owner,
-        repo,
-        buildKey,
-        taskID + '-success',
-        task.onSuccess[successIndex],
-        taskNumber + 's' + successIndex.toString(),
-        buildPath,
-        buildNumber,
-        sha,
-        scm,
-        scmDetails,
-        cache,
-        repoConfig,
-        buildConfig,
-        serverConf
+      const isValid = await taskDetail.isValidTask(
+        task.onSuccess[successIndex].id,
+        cache
       );
+      if (isValid == true) {
+        await addTaskToPending(
+          owner,
+          repo,
+          buildKey,
+          taskID + "-success",
+          task.onSuccess[successIndex],
+          taskNumber + "s" + successIndex.toString(),
+          buildPath,
+          buildNumber,
+          sha,
+          scm,
+          scmDetails,
+          cache,
+          repoConfig,
+          buildConfig,
+          serverConf
+        );
+      }
     }
   }
 
@@ -278,37 +294,43 @@ async function startTask(
       failureIndex++
     ) {
       console.log(
-        '--- saving onFailure task: ' + task.onFailure[failureIndex].id
+        "--- saving onFailure task: " + task.onFailure[failureIndex].id
       );
-      await addTaskToPending(
-        owner,
-        repo,
-        buildKey,
-        taskID + '-failure',
-        task.onFailure[failureIndex],
-        taskNumber + 'f' + failureIndex.toString(),
-        buildPath,
-        buildNumber,
-        sha,
-        scm,
-        scmDetails,
-        cache,
-        repoConfig,
-        buildConfig,
-        serverConf
+      const isValid = await taskDetail.isValidTask(
+        task.onFailure[failureIndex].id,
+        cache
       );
+      if (isValid == true) {
+        await addTaskToPending(
+          owner,
+          repo,
+          buildKey,
+          taskID + "-failure",
+          task.onFailure[failureIndex],
+          taskNumber + "f" + failureIndex.toString(),
+          buildPath,
+          buildNumber,
+          sha,
+          scm,
+          scmDetails,
+          cache,
+          repoConfig,
+          buildConfig,
+          serverConf
+        );
+      }
     }
   }
 
-  console.log(chalk.green('--- Creating task: ' + taskID));
+  console.log(chalk.green("--- Creating task: " + taskID));
   await notification.taskStarted(taskID, taskDetails);
   const queueName = await taskDetail.taskQueue(
     taskDetails.task.id,
     cache,
     serverConf
   );
-  console.log(chalk.green('--- Adding task to queue: ' + queueName));
-  const queue = taskQueue.createTaskQueue('stampede-' + queueName);
+  console.log(chalk.green("--- Adding task to queue: " + queueName));
+  const queue = taskQueue.createTaskQueue("stampede-" + queueName);
   await queue.add(taskDetails, { removeOnComplete: true, removeOnFail: true });
   await queue.close();
 }
@@ -348,7 +370,7 @@ async function addTaskToPending(
   serverConf
 ) {
   const taskID =
-    buildPath + '-' + buildNumber + '-' + task.id + '-' + taskNumber;
+    buildPath + "-" + buildNumber + "-" + task.id + "-" + taskNumber;
   const taskConfig = await taskDetail.taskConfig(
     task.id,
     repoConfig,
@@ -363,10 +385,10 @@ async function addTaskToPending(
     repository: repo,
     buildKey: buildKey,
     buildNumber: buildNumber,
-    buildID: buildPath + '-' + buildNumber,
+    buildID: buildPath + "-" + buildNumber,
     taskID: taskID,
     sha: sha,
-    status: 'pending',
+    status: "pending",
     task: {
       id: task.id,
       number: taskNumber
@@ -374,7 +396,7 @@ async function addTaskToPending(
     config: taskConfig,
     scm: scmDetails
   };
-  console.log(chalk.green('--- Adding pending task: ' + taskID));
+  console.log(chalk.green("--- Adding pending task: " + taskID));
   await cache.addTaskToPendingList(parentTaskID, taskDetails);
 }
 

--- a/lib/taskDetail.js
+++ b/lib/taskDetail.js
@@ -1,4 +1,15 @@
-'use strict';
+"use strict";
+
+/**
+ * isValidTask
+ * @param {*} taskID
+ * @param {*} cache
+ * @return {Boolean} if task is valid or not
+ */
+async function isValidTask(taskID, cache) {
+  const globalTaskConfig = await cache.fetchTaskConfig(taskID);
+  return globalTaskConfig != null ? true : false;
+}
 
 /**
  * taskTitle
@@ -12,7 +23,11 @@ async function taskTitle(taskID, taskConfig, cache) {
     return taskConfig.title;
   } else {
     const globalTasksConfig = await cache.fetchTaskConfig(taskID);
-    return globalTasksConfig.title;
+    if (globalTasksConfig != null && globalTasksConfig.title != null) {
+      return globalTasksConfig.title;
+    } else {
+      return null;
+    }
   }
 }
 
@@ -33,40 +48,40 @@ async function taskConfig(taskID, repoConfig, buildConfig, taskConfig, cache) {
   const globalDefaults = await cache.fetchSystemDefaults();
   const globalOverrides = await cache.fetchSystemOverrides();
   let config = {};
-  console.log('--- global task config:');
+  console.log("--- global task config:");
   console.dir(globalTasksConfig.config);
   for (let index = 0; index < globalTasksConfig.config.length; index++) {
     const key = globalTasksConfig.config[index].key;
-    console.log('--- key: ' + key);
+    console.log("--- key: " + key);
     // System default
     let value = globalDefaults.defaults[key];
-    let source = 'systemDefault';
+    let source = "systemDefault";
     // Top level repo config
     if (repoConfig.config != null && repoConfig.config[key] != null) {
       value = repoConfig.config[key];
-      source = 'repoConfig';
+      source = "repoConfig";
     }
     // Build config
     if (buildConfig.config != null && buildConfig.config[key] != null) {
       value = buildConfig.config[key];
-      source = 'buildConfig';
+      source = "buildConfig";
     }
     // Task config
     if (taskConfig.config != null && taskConfig.config[key] != null) {
       value = taskConfig.config[key];
-      source = 'taskConfig';
+      source = "taskConfig";
     }
     // System override
     if (globalOverrides.overrides[key] != null) {
       value = globalOverrides.overrides[key];
-      source = 'overrides';
+      source = "overrides";
     }
     if (value != null) {
       config[key] = value;
-      console.log('--- derived value for ' + key + ' from ' + source);
+      console.log("--- derived value for " + key + " from " + source);
     }
   }
-  console.log('--- task config is:');
+  console.log("--- task config is:");
   console.dir(config);
   return config;
 }
@@ -78,7 +93,7 @@ async function taskConfig(taskID, repoConfig, buildConfig, taskConfig, cache) {
  * @param {*} serverConf
  */
 async function taskQueue(taskID, cache, serverConf) {
-  console.log('--- taskQueue:');
+  console.log("--- taskQueue:");
   const globalTasksConfig = await cache.fetchTaskConfig(taskID);
   console.log(globalTasksConfig.taskQueue);
   if (globalTasksConfig == null) {
@@ -89,6 +104,7 @@ async function taskQueue(taskID, cache, serverConf) {
     : serverConf.taskQueueDefault;
 }
 
+module.exports.isValidTask = isValidTask;
 module.exports.taskTitle = taskTitle;
 module.exports.taskConfig = taskConfig;
 module.exports.taskQueue = taskQueue;


### PR DESCRIPTION
This PR fixes a problem when the `.stampede.yaml` contains a task that hasn't been configured yet, or is a typo. Now the server will just ignore any tasks that are requested that it doesn't recognize.