### PR TITLE
♻️ Reuse client and subscriber redis connection for all queues

### DIFF
--- a/lib/taskQueue.js
+++ b/lib/taskQueue.js
@@ -1,15 +1,32 @@
-'use strict';
+"use strict";
 
-const Queue = require('bull');
+const Queue = require("bull");
+var Redis = require("ioredis");
 
 let redisConfig = {};
+let redisClient = null;
+let redisSubscriber = null;
 
 function setRedisConfig(config) {
   redisConfig = config;
+  redisClient = new Redis(config.redis);
+  redisSubscriber = new Redis(config.redis);
 }
 
 function createTaskQueue(name) {
-  return new Queue(name, redisConfig);
+  const opts = {
+    createClient: function(type) {
+      switch (type) {
+        case "client":
+          return redisClient;
+        case "subscriber":
+          return redisSubscriber;
+        default:
+          return new Redis(redisConfig.redis);
+      }
+    }
+  };
+  return new Queue(name, opts);
 }
 
 module.exports.setRedisConfig = setRedisConfig;


### PR DESCRIPTION
This PR adds some optimization to how the Bull queues are created, reusing the client and subscriber Redis connections across all queues. This will reduce the overall number of Redis connections needed as by default there are 3 connections for every queue. Now there should be 2 initial connections and then only 1 per queue.