### PR TITLE
✨ Sending config source along with value

### DIFF
--- a/lib/taskDetail.js
+++ b/lib/taskDetail.js
@@ -77,7 +77,7 @@ async function taskConfig(taskID, repoConfig, buildConfig, taskConfig, cache) {
       source = "overrides";
     }
     if (value != null) {
-      config[key] = value;
+      config[key] = { value: value, source: source };
       console.log("--- derived value for " + key + " from " + source);
     }
   }


### PR DESCRIPTION
This PR updates the server to send the config source along with the value. The source was calculated but never made it into the task details. Note that this update requires a new version of the worker since the value has moved down a level in the json.

Closes #120 