### PR TITLE
🐛 Make sure notifications are sent in order

### DIFF
--- a/lib/notification.js
+++ b/lib/notification.js
@@ -34,7 +34,7 @@ async function repositoryEventReceived(event, payload) {
     id: event,
     payload: payload
   };
-  sendNotification(notification);
+  await sendNotification(notification);
 }
 
 /**
@@ -48,7 +48,7 @@ async function buildStarted(build, payload) {
     id: build,
     payload: payload
   };
-  sendNotification(notification);
+  await sendNotification(notification);
 }
 
 /**
@@ -62,7 +62,7 @@ async function buildCompleted(build, payload) {
     id: build,
     payload: payload
   };
-  sendNotification(notification);
+  await sendNotification(notification);
 }
 
 /**
@@ -76,7 +76,7 @@ async function taskStarted(task, payload) {
     id: task,
     payload: payload
   };
-  sendNotification(notification);
+  await sendNotification(notification);
 }
 
 /**
@@ -90,7 +90,7 @@ async function taskCompleted(task, payload) {
     id: task,
     payload: payload
   };
-  sendNotification(notification);
+  await sendNotification(notification);
 }
 
 /**
@@ -104,7 +104,7 @@ async function taskUpdated(task, payload) {
     id: task,
     payload: payload
   };
-  sendNotification(notification);
+  await sendNotification(notification);
 }
 
 /**
@@ -117,7 +117,7 @@ async function workerHeartbeat(heartbeat) {
     id: heartbeat.workerID,
     payload: heartbeat
   };
-  sendNotification(notification);
+  await sendNotification(notification);
 }
 
 // Private Methods


### PR DESCRIPTION
This PR fixes a minor issue in the server where it is possible that some notifications are sent out of order. This may only be a problem in the test harness because there are multiple notification queues. 

Closes #138 