### PR TITLE
🔥 Removed initialization of tasks, defaults and overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,16 @@ config param=config value
 
 The configuration parameters are:
 
-| Config | Default | Description |
-| ------ | ------- | ----------- |
-| redisHost | localhost | The host name for redis |
-| redisPort | 6379 | The port for redis |
-| redisPassword | null | The password for redis if needed |
-| githubAppID | null | The app id assigned to the app by GitHub |
-| githubAppPEMPath | null | Path to the apps PEM file |
-| githubHost | null | The url for the github API (for GHE it would be https://yourghehost/api/v3) |
-| stampedeConfigPath | null | The path to where the task list is located |
-| notificationQueues | null | The CSV list of notification queues. For example the CLI defaults to stampede-cli, so at 
-a minimum you should configure stampede-cli as a notification queue here |
+| Config                                                                   | Default   | Description                                                                              |
+| ------------------------------------------------------------------------ | --------- | ---------------------------------------------------------------------------------------- |
+| redisHost                                                                | localhost | The host name for redis                                                                  |
+| redisPort                                                                | 6379      | The port for redis                                                                       |
+| redisPassword                                                            | null      | The password for redis if needed                                                         |
+| githubAppID                                                              | null      | The app id assigned to the app by GitHub                                                 |
+| githubAppPEMPath                                                         | null      | Path to the apps PEM file                                                                |
+| githubHost                                                               | null      | The url for the github API (for GHE it would be https://yourghehost/api/v3)              |
+| notificationQueues                                                       | null      | The CSV list of notification queues. For example the CLI defaults to stampede-cli, so at |
+| a minimum you should configure stampede-cli as a notification queue here |
 
 Example:
 
@@ -43,22 +42,3 @@ githubHost=https://ourghe/api/v3
 redisHost=localhost
 stampedeConfigPath=/stampedestuff
 notificationQueues=stampede-cli
-
-## Configuring available tasks
-
-The list of available tasks is contained in a tasks.yaml file that is found in the `stampedeConfigPath`. This represents
-the tasks that the stampede system knows about, while the configuration per-repo is separate.
-
-Format of the tasks file is:
-
-- id: ...
-  title: ... 
-  config:
-    - key: ...
-    - key: ...
-    - key: ...
-
-You can include multiple tasks in the file by having multiples of these sections, one per task. The id can be anything but
-make it descriptive so when you are setting up the worker you will remember what it is. For example: compile-ios-app or upload-artifacts.
-
-

--- a/bin/stampede-server.js
+++ b/bin/stampede-server.js
@@ -25,7 +25,6 @@ const conf = require("rc")("stampede", {
   githubAppPEMPath: null,
   githubAppPEM: null,
   githubHost: null,
-  stampedeConfigPath: null,
   responseQueue: "response",
   notificationQueues: "",
   stampedeFileName: ".stampede.yaml",
@@ -44,7 +43,6 @@ console.log(chalk.yellow(module.exports.version));
 console.log(chalk.red("Redis Host: " + conf.redisHost));
 console.log(chalk.red("Redis Port: " + conf.redisPort));
 console.log(chalk.red("Web Port: " + conf.webPort));
-console.log(chalk.red("Config Path: " + conf.stampedeConfigPath));
 console.log(chalk.red("SCM: " + conf.scm));
 console.log(chalk.red("GitHub APP ID: " + conf.githubAppID));
 console.log(chalk.red("GitHub PEM Path: " + conf.githubAppPEMPath));

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,7 +1,7 @@
-'use strict';
-const fs = require('fs');
-const yaml = require('js-yaml');
-const chalk = require('chalk');
+"use strict";
+const fs = require("fs");
+const yaml = require("js-yaml");
+const chalk = require("chalk");
 
 /**
  * initialize
@@ -11,38 +11,7 @@ const chalk = require('chalk');
 async function initialize(conf, cache) {
   // If we have a local path, attempt to initialize our config from there
   if (conf.stampedeConfigPath != null) {
-    await initializeTasks(conf, cache);
     await initializeQueues(conf, cache);
-    await initializeDefaults(conf, cache);
-    await initializeOverrides(conf, cache);
-  }
-}
-
-/**
- * initializeTasks
- * @param {*} conf
- * @param {*} cache
- */
-async function initializeTasks(conf, cache) {
-  await cache.removeTaskConfig();
-  const tasksPath = conf.stampedeConfigPath + '/tasks';
-  if (fs.existsSync(tasksPath)) {
-    const files = fs.readdirSync(tasksPath).filter(function(file) {
-      return file.endsWith('.yaml');
-    });
-    for (let index = 0; index < files.length; index++) {
-      const taskDetails = yaml.safeLoad(
-        fs.readFileSync(conf.stampedeConfigPath + '/tasks/' + files[index])
-      );
-      if (taskDetails.id != null) {
-        await cache.storeTask(taskDetails.id);
-        await cache.storeTaskConfig(taskDetails.id, taskDetails);
-      } else {
-        console.log(
-          chalk.red('Skipping ' + files[index] + ' as no task id found')
-        );
-      }
-    }
   }
 }
 
@@ -52,48 +21,14 @@ async function initializeTasks(conf, cache) {
  * @param {*} cache
  */
 async function initializeQueues(conf, cache) {
-  if (fs.existsSync(conf.stampedeConfigPath + '/queues.yaml')) {
+  if (fs.existsSync(conf.stampedeConfigPath + "/queues.yaml")) {
     const queues = yaml.safeLoad(
-      fs.readFileSync(conf.stampedeConfigPath + '/queues.yaml')
+      fs.readFileSync(conf.stampedeConfigPath + "/queues.yaml")
     );
     cache.storeSystemQueues(queues);
-    console.log(chalk.green('--- Saved queues from queues.yaml'));
+    console.log(chalk.green("--- Saved queues from queues.yaml"));
   } else {
     cache.storeSystemQueues({ defaults: [] });
-  }
-}
-
-/**
- * initializeDefaults
- * @param {*} conf
- * @param {*} cache
- */
-async function initializeDefaults(conf, cache) {
-  if (fs.existsSync(conf.stampedeConfigPath + '/defaults.yaml')) {
-    const defaults = yaml.safeLoad(
-      fs.readFileSync(conf.stampedeConfigPath + '/defaults.yaml')
-    );
-    cache.storeSystemDefaults(defaults);
-    console.log(chalk.green('--- Saved config defaults from defaults.yaml'));
-  } else {
-    cache.storeSystemDefaults({ defaults: [] });
-  }
-}
-
-/**
- * initializeOverrides
- * @param {*} conf
- * @param {*} cache
- */
-async function initializeOverrides(conf, cache) {
-  if (fs.existsSync(conf.stampedeConfigPath + '/overrides.yaml')) {
-    const overrides = yaml.safeLoad(
-      fs.readFileSync(conf.stampedeConfigPath + '/overrides.yaml')
-    );
-    cache.storeSystemOverrides(overrides);
-    console.log(chalk.green('--- Saved config overrides from overrides.yaml'));
-  } else {
-    cache.storeSystemOverrides({ overrides: [] });
   }
 }
 
@@ -122,7 +57,7 @@ async function findRepoConfig(
   let config = await cache.fetchRepoConfig(owner, repo);
   if (config == null) {
     console.log(
-      chalk.green('--- No override found in redis, looking into the repo')
+      chalk.green("--- No override found in redis, looking into the repo")
     );
     config = await scm.findRepoConfig(
       owner,


### PR DESCRIPTION
This PR removes the initialization phase that loads tasks, defaults and overrides on server startup. We are decoupling this from the server as we expect admins to manage this lifecycle instead. These items should be managed using the cli or portal tools.

💥 This is a potential breaking change for testing since these items will not be loaded immediately now. The `stampede-server-test` app has to be modified to ensure these values are loaded for testing. Existing stampede installs should be ok since these values are already in the cache.

closes #146 