### PR TITLE
🐛 added synchronize actions to trigger pr checks

### DIFF
--- a/events/pullRequest.js
+++ b/events/pullRequest.js
@@ -20,7 +20,11 @@ async function handle(req, serverConf, cache, scm) {
   //  console.dir(event)
   notification.repositoryEventReceived("pull_request", event);
 
-  if (event.action === "opened" || event.action === "reopened") {
+  if (
+    event.action === "opened" ||
+    event.action === "reopened" ||
+    event.action === "synchronize"
+  ) {
     await checkRun.createCheckRun(
       event.owner,
       event.repo,


### PR DESCRIPTION
This PR adds the action that we get when a PR based on a forked repo is updated. This action should trigger the checks just like a normal push/update.