### PR TITLE
✨ taskExecute now allows for overriding the task queue

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -67,6 +67,7 @@ async function startBuild(
     buildNumber,
     scm,
     scmDetails,
+    buildDetails.overrideTaskQueue,
     cache,
     repoConfig,
     buildConfig,

--- a/lib/task.js
+++ b/lib/task.js
@@ -16,6 +16,7 @@ const taskQueue = require("./taskQueue");
  * @param {*} buildNumber
  * @param {*} scm
  * @param {*} scmDetails
+ * @param {*} overrideTaskQueue
  * @param {*} cache
  * @param {*} repoConfig
  * @param {*} buildConfig
@@ -31,6 +32,7 @@ async function startTasks(
   buildNumber,
   scm,
   scmDetails,
+  overrideTaskQueue,
   cache,
   repoConfig,
   buildConfig,
@@ -61,6 +63,7 @@ async function startTasks(
       buildNumber,
       scm,
       scmDetails,
+      overrideTaskQueue,
       cache,
       repoConfig,
       buildConfig,
@@ -105,6 +108,7 @@ async function addTaskToActiveList(
  * @param {*} buildNumber
  * @param {*} scm
  * @param {*} scmDetails
+ * @param {*} overrideTaskQueue
  * @param {*} cache
  * @param {*} repoConfig
  * @param {*} buildConfig
@@ -121,6 +125,7 @@ async function startTask(
   buildNumber,
   scm,
   scmDetails,
+  overrideTaskQueue,
   cache,
   repoConfig,
   buildConfig,
@@ -184,8 +189,11 @@ async function startTask(
     }
   };
 
-  const queueName = await taskDetail.taskQueue(taskDetails.task.id, cache);
+  let queueName = await taskDetail.taskQueue(taskDetails.task.id, cache);
   if (queueName != null) {
+    if (overrideTaskQueue != null) {
+      queueName = overrideTaskQueue;
+    }
     console.log(chalk.green("--- Creating task: " + taskID));
     await notification.taskStarted(taskID, taskDetails);
     taskDetails.taskQueue = queueName;

--- a/lib/taskExecute.js
+++ b/lib/taskExecute.js
@@ -42,6 +42,7 @@ async function handle(job, serverConf, cache, scm) {
       buildDetails.sha = job.scmConfig.release.sha;
       buildDetails.release = job.scmConfig.release.name;
     }
+    buildDetails.overrideTaskQueue = job.taskQueue;
 
     console.log("-- build details:");
     console.dir(buildDetails);


### PR DESCRIPTION
This PR adds the ability for the taskExecute request from the Portal to include a taskQueue that will override whatever the task is normally configured for. This allows you to manually execute tasks on any queue. Very helpful for testing a node as you can put the worker into a mode where it reads from a specific queue and then send a task to it directly.