### PR TITLE
🐛 Ignore the check_suite requested event

### DIFF
--- a/events/checkSuite.js
+++ b/events/checkSuite.js
@@ -25,7 +25,7 @@ async function handle(req, serverConf, cache, scm, db) {
   }
 
   // Ignore actions we don't care about
-  if (event.action !== "requested" && event.action !== "rerequested") {
+  if (event.action !== "rerequested") {
     return { status: "ignored, not an action we respond to" };
   }
 


### PR DESCRIPTION
This PR fixes a bug that was causing too many builds to run. Ignoring the check_suite `requested` action should fix this. So far I haven't seen a case where we need to respond to this for PRs since we also get the PR events.