### PR TITLE
✨ Now capturing repos that dont have a stampede file

### DIFF
--- a/events/checkRun.js
+++ b/events/checkRun.js
@@ -21,6 +21,8 @@ async function handle(req, serverConf, cache, scm, db) {
     return { status: "ignored, not our app id" };
   }
 
+  await db.storeRepository(event.owner, event.repo);
+
   if (event.action === "rerequested") {
     for (let index = 0; index < event.pullRequests.length; index++) {
       await checkRun.createCheckRun(

--- a/events/checkSuite.js
+++ b/events/checkSuite.js
@@ -24,6 +24,8 @@ async function handle(req, serverConf, cache, scm, db) {
     return { status: "ignored, not our app id" };
   }
 
+  await db.storeRepository(event.owner, event.repo);
+
   // Ignore actions we don't care about
   if (event.action !== "rerequested") {
     return { status: "ignored, not an action we respond to" };

--- a/events/pullRequest.js
+++ b/events/pullRequest.js
@@ -20,6 +20,8 @@ async function handle(req, serverConf, cache, scm, db) {
   //  console.dir(event)
   notification.repositoryEventReceived("pull_request", event);
 
+  await db.storeRepository(event.owner, event.repo);
+
   if (
     event.action === "opened" ||
     event.action === "reopened" ||

--- a/events/push.js
+++ b/events/push.js
@@ -19,6 +19,8 @@ async function handle(req, serverConf, cache, scm, db) {
   console.dir(event);
   notification.repositoryEventReceived("push", event);
 
+  await db.storeRepository(event.owner, event.repo);
+
   if (event.created === true || event.deleted === true) {
     console.log("--- Ignoring push since it is created or deleted");
     return { status: "ignoring due to created or pushed" };

--- a/events/release.js
+++ b/events/release.js
@@ -20,6 +20,8 @@ async function handle(req, serverConf, cache, scm, db) {
   console.dir(event);
   notification.repositoryEventReceived("release", event);
 
+  await db.storeRepository(event.owner, event.repo);
+
   if (event.action !== "published") {
     console.log("--- Ignoring as the release is not marked as published");
     return { status: "not a published release, ignoring" };

--- a/scm/testMode.js
+++ b/scm/testMode.js
@@ -1,7 +1,7 @@
-'use strict'
+"use strict";
 
-const fs = require('fs')
-const yaml = require('js-yaml')
+const fs = require("fs");
+const yaml = require("js-yaml");
 
 /**
  * findRepoConfig
@@ -13,14 +13,23 @@ const yaml = require('js-yaml')
  */
 async function findRepoConfig(owner, repo, stampedeFile, sha, serverConf) {
   if (serverConf.testModeRepoConfigPath != null) {
-    const path = serverConf.testModeRepoConfigPath + owner + '/' + repo + '/.stampede.yaml'
-    console.log('--- loading repo config: ' + path)
-    const testModeConfigFile = fs.readFileSync(path)
-    const config = yaml.safeLoad(testModeConfigFile)
-    console.dir(config)
-    return config
+    try {
+      const path =
+        serverConf.testModeRepoConfigPath +
+        owner +
+        "/" +
+        repo +
+        "/.stampede.yaml";
+      console.log("--- loading repo config: " + path);
+      const testModeConfigFile = fs.readFileSync(path);
+      const config = yaml.safeLoad(testModeConfigFile);
+      console.dir(config);
+      return config;
+    } catch (e) {
+      return null;
+    }
   } else {
-    return null
+    return null;
   }
 }
 
@@ -28,22 +37,29 @@ async function findRepoConfig(owner, repo, stampedeFile, sha, serverConf) {
  * createCheckRun
  * @param {*} check
  */
-async function createCheckRun(owner, repo, taskTitle, head_sha, external_id,
-  started_at, serverConf) {
-  console.log('--- createCheckRun')
-  console.log('owner: ' + owner)
-  console.log('repo: ' + repo)
-  console.log('task: ' + taskTitle)
-  console.log('taskTitle: ' + taskTitle)
-  console.log('head_sha: ' + head_sha)
-  console.log('external_id: ' + external_id)
-  console.log('started_at: ' + started_at)
-  console.dir(serverConf)
+async function createCheckRun(
+  owner,
+  repo,
+  taskTitle,
+  head_sha,
+  external_id,
+  started_at,
+  serverConf
+) {
+  console.log("--- createCheckRun");
+  console.log("owner: " + owner);
+  console.log("repo: " + repo);
+  console.log("task: " + taskTitle);
+  console.log("taskTitle: " + taskTitle);
+  console.log("head_sha: " + head_sha);
+  console.log("external_id: " + external_id);
+  console.log("started_at: " + started_at);
+  console.dir(serverConf);
   return {
     data: {
-      id: '123',
-    },
-  }
+      id: "123"
+    }
+  };
 }
 
 /**
@@ -56,10 +72,10 @@ async function getTagInfo(owner, repo, ref, serverConf) {
   return {
     data: {
       object: {
-        sha: '123',
-      },
-    },
-  }
+        sha: "123"
+      }
+    }
+  };
 }
 
 /**
@@ -70,10 +86,10 @@ async function getTagInfo(owner, repo, ref, serverConf) {
  * @param {*} update
  */
 async function updateCheck(owner, repo, serverConf, update) {
-  console.log('--- updateCheck')
+  console.log("--- updateCheck");
 }
 
-module.exports.findRepoConfig = findRepoConfig
-module.exports.createCheckRun = createCheckRun
-module.exports.getTagInfo = getTagInfo
-module.exports.updateCheck = updateCheck
+module.exports.findRepoConfig = findRepoConfig;
+module.exports.createCheckRun = createCheckRun;
+module.exports.getTagInfo = getTagInfo;
+module.exports.updateCheck = updateCheck;


### PR DESCRIPTION
This PR updates the server to track repos that it receives events for, even if they have no .stampede.yaml file. This will allow for executing tasks, or setting up a cached config before the repo is updated.