### PR TITLE
🔥 Removed change build number button

### DIFF
--- a/views/repositories/repositoryDetails.pug
+++ b/views/repositories/repositoryDetails.pug
@@ -21,7 +21,7 @@ block content
               +tableRow()
                 +tableCell('Next Build Number')
                 +tableCell(nextBuildNumber)
-                +tableCellButton("Change", "/repositories")
+                +tableCell('')
               +tableRow()
                 +tableCell('Config Source')
                 +tableCell(configSource)


### PR DESCRIPTION
This PR removes the change build number button from the repository details screen as it is non-functional.

closes #219 