### PR TITLE
✨ Actions can now be requested from a PR using the stampede check

### DIFF
--- a/events/checkRun.js
+++ b/events/checkRun.js
@@ -38,6 +38,23 @@ async function handle(req, serverConf, cache, scm, db) {
         db
       );
     }
+  } else if (event.action === "requested_action") {
+    for (let index = 0; index < event.pullRequests.length; index++) {
+      await checkRun.createCheckRunForAction(
+        event.owner,
+        event.repo,
+        event.sha,
+        event.pullRequests[index],
+        event.cloneURL,
+        event.sshURL,
+        event.actionID,
+        event.externalID,
+        scm,
+        cache,
+        serverConf,
+        db
+      );
+    }
   } else {
     console.log("--- ignoring check run, not a rerequested one");
     return { status: "check run ignored as it was not a rerequested check" };
@@ -55,6 +72,12 @@ function parseEvent(req) {
   const parts = fullName.split("/");
   const owner = parts[0];
   const repo = parts[1];
+
+  let actionID = null;
+  if (req.body.requested_action != null) {
+    actionID = req.body.requested_action.identifier;
+  }
+
   return {
     appID: req.body.check_run.app.id,
     owner: owner,
@@ -68,7 +91,8 @@ function parseEvent(req) {
     cloneURL: req.body.repository.clone_url,
     sshURL: req.body.repository.ssh_url,
     checkRunID: req.body.check_run.id,
-    externalID: req.body.check_run.external_id
+    externalID: req.body.check_run.external_id,
+    actionID: actionID
   };
 }
 

--- a/events/pullRequest.js
+++ b/events/pullRequest.js
@@ -191,6 +191,7 @@ async function pullRequestEdit(
     repoConfig,
     repoConfig.pullrequestedit,
     repoConfig.pullrequestedit.tasks,
+    [],
     cache,
     serverConf,
     db

--- a/events/push.js
+++ b/events/push.js
@@ -93,6 +93,7 @@ async function handle(req, serverConf, cache, scm, db) {
     repoConfig,
     branchConfig,
     branchConfig.tasks,
+    [],
     cache,
     serverConf,
     db

--- a/events/release.js
+++ b/events/release.js
@@ -122,6 +122,7 @@ async function handle(req, serverConf, cache, scm, db) {
     repoConfig,
     releaseConfig,
     releaseConfig.tasks,
+    [],
     cache,
     serverConf,
     db

--- a/lib/build.js
+++ b/lib/build.js
@@ -11,6 +11,8 @@ const notification = require("../lib/notification");
  * @param {*} scmDetails
  * @param {*} repoConfig
  * @param {*} buildConfig
+ * @param {*} tasks
+ * @param {*} actions
  * @param {*} cache
  * @param {*} serverConf
  * @param {*} db
@@ -22,6 +24,7 @@ async function startBuild(
   repoConfig,
   buildConfig,
   tasks,
+  actions,
   cache,
   serverConf,
   db
@@ -32,6 +35,7 @@ async function startBuild(
   console.dir(repoConfig);
   console.dir(buildConfig);
   console.dir(tasks);
+  console.dir(actions);
 
   const buildPath =
     buildDetails.owner + "-" + buildDetails.repo + "-" + buildDetails.buildKey;
@@ -78,6 +82,7 @@ async function startBuild(
     buildDetails.repo,
     buildDetails.sha,
     buildDetails.buildPath + "-" + buildDetails.buildNumber,
+    actions,
     serverConf
   );
 

--- a/lib/checkRun.js
+++ b/lib/checkRun.js
@@ -4,6 +4,7 @@ const chalk = require("chalk");
 
 const build = require("./build");
 const config = require("./config");
+const task = require("./task");
 
 /**
  * Create a check run
@@ -64,7 +65,7 @@ async function createCheckRun(
     repoConfig.pullrequests == null ||
     repoConfig.pullrequests.tasks == null
   ) {
-    await scm.createStampedeCheck(owner, repo, sha, null, serverConf);
+    await scm.createStampedeCheck(owner, repo, sha, null, [], serverConf);
     console.log(chalk.red("--- Unable to find tasks. Unable to continue."));
     return;
   }
@@ -72,7 +73,7 @@ async function createCheckRun(
   console.dir(repoConfig.pullrequests);
   console.dir(repoConfig.pullrequests.tasks);
   if (repoConfig.pullrequests.tasks.length === 0) {
-    await scm.createStampedeCheck(owner, repo, sha, null, serverConf);
+    await scm.createStampedeCheck(owner, repo, sha, null, [], serverConf);
     console.log(chalk.red("--- Task list was empty. Unable to continue."));
     return;
   }
@@ -112,10 +113,144 @@ async function createCheckRun(
     repoConfig,
     repoConfig.pullrequests,
     repoConfig.pullrequests.tasks,
+    repoConfig.pullrequests.actions != null
+      ? repoConfig.pullrequests.actions
+      : [],
     cache,
     serverConf,
     db
   );
 }
 
+/**
+ * Create a check run
+ * @param {*} owner
+ * @param {*} repo
+ * @param {*} sha
+ * @param {*} pullRequest
+ * @param {*} cloneURL
+ * @param {*} sshURL
+ * @param {*} scm
+ * @param {*} cache
+ * @param {*} serverConf
+ * @param {*} db
+ */
+async function createCheckRunForAction(
+  owner,
+  repo,
+  sha,
+  pullRequest,
+  cloneURL,
+  sshURL,
+  actionID,
+  externalID,
+  scm,
+  cache,
+  serverConf,
+  db
+) {
+  console.log(
+    chalk.green(
+      "--- Creating check run for " +
+        owner +
+        " " +
+        repo +
+        " PR " +
+        pullRequest.number +
+        " Action " +
+        actionID
+    )
+  );
+
+  const repoConfig = await config.findRepoConfig(
+    owner,
+    repo,
+    sha,
+    serverConf.stampedeFileName,
+    scm,
+    cache,
+    serverConf
+  );
+  console.dir(repoConfig);
+  if (repoConfig == null) {
+    console.log(
+      chalk.red(
+        "--- Unable to determine config, no found in Redis or the project. Unable to continue"
+      )
+    );
+    return;
+  }
+
+  if (
+    repoConfig.pullrequests == null ||
+    repoConfig.pullrequests.actions == null
+  ) {
+    console.log(chalk.red("--- Unable to find actions. Unable to continue."));
+    return;
+  }
+
+  console.dir(repoConfig.pullrequests);
+  console.dir(repoConfig.pullrequests.actions);
+  if (repoConfig.pullrequests.actions.length === 0) {
+    console.log(chalk.red("--- Actions list was empty. Unable to continue."));
+    return;
+  }
+
+  const actionIndex = parseInt(actionID);
+  const action = repoConfig.pullrequests.actions[actionIndex];
+  const externalIDParts = externalID.split("-");
+  const buildNumber = externalIDParts[externalIDParts.length - 1];
+
+  const pullRequestDetails = {
+    number: pullRequest.number,
+    title: pullRequest.title,
+    head: {
+      ref: pullRequest.head.ref,
+      sha: sha
+    },
+    base: {
+      ref: pullRequest.base.ref,
+      sha: pullRequest.base.sha
+    }
+  };
+
+  const buildDetails = {
+    owner: owner,
+    repo: repo,
+    sha: sha,
+    pullRequest: pullRequestDetails,
+    buildKey: "pullrequest-" + pullRequest.number
+  };
+
+  const scmDetails = {
+    id: serverConf.scm,
+    cloneURL: cloneURL,
+    sshURL: sshURL,
+    pullRequest: pullRequestDetails
+  };
+
+  const buildPath =
+    buildDetails.owner + "-" + buildDetails.repo + "-" + buildDetails.buildKey;
+  const buildConfig = repoConfig.pullrequests;
+
+  task.startTasks(
+    buildDetails.owner,
+    buildDetails.repo,
+    buildDetails.buildKey,
+    buildDetails.sha,
+    [action],
+    buildPath,
+    buildNumber,
+    scm,
+    scmDetails,
+    buildDetails.overrideTaskQueue,
+    cache,
+    repoConfig,
+    buildConfig,
+    serverConf,
+    db
+  );
+}
+
 module.exports.createCheckRun = createCheckRun;
+module.exports.createCheckRunForAction = createCheckRunForAction;

--- a/lib/taskExecute.js
+++ b/lib/taskExecute.js
@@ -99,6 +99,7 @@ async function handle(job, serverConf, cache, scm, db) {
       repoConfig,
       buildConfig,
       taskList,
+      [],
       cache,
       serverConf,
       db

--- a/scm/github.js
+++ b/scm/github.js
@@ -266,6 +266,7 @@ async function createStampedeCheck(
   repo,
   head_sha,
   buildKey,
+  actions,
   serverConf
 ) {
   let welcomeString =
@@ -291,6 +292,21 @@ async function createStampedeCheck(
 
   let externalID = buildKey != null ? buildKey : "stampede";
 
+  let actionsList = [];
+
+  if (actions.length > 0) {
+    welcomString +=
+      "\nSome additional tasks are available for you to execute. You can trigger them from one of the buttons above.\n";
+  }
+
+  for (let index = 0; index < actions.length; index++) {
+    actionsList.push({
+      label: actions[index].id,
+      description: actions[index].id,
+      identifier: index.toString()
+    });
+  }
+
   const authorizedOctokit = await getAuthorizedOctokit(owner, repo, serverConf);
   console.log("Creating Stampede check run");
   const checkRun = await authorizedOctokit.checks.create({
@@ -307,7 +323,8 @@ async function createStampedeCheck(
       title: "Stampede Build",
       summary: welcomeString,
       text: ""
-    }
+    },
+    actions: actionsList
   });
   return checkRun;
 }

--- a/scm/testMode.js
+++ b/scm/testMode.js
@@ -104,6 +104,7 @@ async function createStampedeCheck(
   repo,
   head_sha,
   buildKey,
+  actions,
   serverConf
 ) {}
 


### PR DESCRIPTION
This PR adds new functionality to a PR where you can attach ad-hoc actions to the PR check. This allows you to configure tasks that only need to be run occasionally and can be triggered manually right from the GitHub UI. These actions show up in the Stampede check for a PR. They are configured the same as tasks (they are tasks!), but in a new key in the .stampede.yaml file named 'actions'.

For example:

```
pullrequests:
  config:
  tasks:
    - id: lint-nodejs
  actions:
    - id: pr-standards
    - id: test-config
    - id: long-running
```

closes #170 