### PR TITLE
✨Added API for executing a single task

### DIFF
--- a/api/executeTask.js
+++ b/api/executeTask.js
@@ -1,0 +1,55 @@
+"use strict";
+const taskExecute = require("../lib/taskExecute");
+
+/**
+ * handle
+ * @param {*} req
+ * @param {*} res
+ * @param {*} serverConf
+ * @param {*} cache
+ * @param {*} scm
+ * @param {*} db
+ */
+async function handle(req, res, serverConf, cache, scm, db) {
+  // Expected body:
+  // owner: ""
+  // repository: "",
+  // buildType: "Pull Request" | "Branch" | "Release",
+  // task: the-task-id,
+  // taskConfig:
+  //    "key": "value",
+  // scmConfig:
+  //  pullRequest
+  //    number
+  //    title
+  //    head
+  //      ref
+  //      sha
+  //    base
+  //      ref
+  //      sha
+  //  OR
+  //  branch
+  //    name
+  //    sha
+  //  OR
+  //  release
+  //    name
+  //    tag
+  //    sha
+  // taskQueue: ""
+  const taskDetails = await cache.fetchTaskConfig(req.body.task);
+  console.log("got task details for task: " + req.body.task);
+  console.dir(taskDetails);
+  if (taskDetails != null) {
+    const executeConfig = req.body;
+    executeConfig.task = taskDetails;
+
+    taskExecute.handle(executeConfig, serverConf, cache, scm, db);
+    res.send({ status: "ok" });
+  } else {
+    res.send({ status: "task not found" });
+  }
+}
+
+module.exports.handle = handle;

--- a/lib/api.js
+++ b/lib/api.js
@@ -11,6 +11,7 @@ const buildDetails = require("../api/buildDetails");
 const workerStatus = require("../api/workerStatus");
 const recentBuilds = require("../api/recentBuilds");
 const queueSummary = require("../api/queueSummary");
+const executeTask = require("../api/executeTask");
 
 // Admin
 const adminTasks = require("../api/admin/tasks");
@@ -56,6 +57,10 @@ function router(dependencies) {
 
   basicRouter.get("/api/queueSummary", function(req, res) {
     queueSummary.handle(req, res, serverConf, cache, db);
+  });
+
+  basicRouter.post("/api/executeTask", function(req, res) {
+    executeTask.handle(req, res, serverConf, cache, scm, db);
   });
 
   // Admin


### PR DESCRIPTION
This PR adds an API endpoint `/api/executeTask` for executing a single task in a repo. This doesn't require a .stampede.yaml as you are required to specify all the details for running the task. Note that the task must exist in the configuration of the system, however.

closes #175 
