### PR TITLE
🐛 Fixed issue with repository build branch setting

### DIFF
--- a/lib/repositoryBuild.js
+++ b/lib/repositoryBuild.js
@@ -22,9 +22,12 @@ async function execute(owner, repository, buildID, buildInfo, dependencies) {
     const scmDetails = {
       id: dependencies.serverConfig.scm,
       cloneURL: buildInfo.cloneURL,
-      sshURL: buildInfo.sshURL
+      sshURL: buildInfo.sshURL,
+      branch: {
+        name: buildInfo.branch,
+        sha: "latest"
+      }
     };
-    scmDetails.branch = buildInfo.branch;
 
     console.log("-- scm details:");
     console.dir(scmDetails);


### PR DESCRIPTION
This PR fixes an issue with repository builds and how they were passing the branch name to the worker. This was causing errors in the worker with the STAMP_BRANCH environment variable not getting set properly.

closes #239 