### PR TITLE
✨ Server now creates a temporary access token for tasks to use during build

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -55,6 +55,14 @@ async function startBuild(
   // later
   buildDetails.stampedeConfig = repoConfig;
 
+  // Get an access token for any tasks to use for this build
+  const accessToken = await scm.getAccessToken(
+    buildDetails.owner,
+    buildDetails.repo,
+    serverConf
+  );
+  scmDetails.accessToken = accessToken;
+
   // Get the build started in the cache and then the initial tasks
   await cache.addBuildToActiveList(
     buildDetails.buildPath + "-" + buildDetails.buildNumber

--- a/scm/github.js
+++ b/scm/github.js
@@ -77,6 +77,37 @@ async function getAuthorizedOctokit(owner, repo, serverConf) {
   return authorizedOctokit;
 }
 
+async function getAccessToken(owner, repo, serverConf) {
+  const app = new App({
+    id: serverConf.githubAppID,
+    privateKey: serverConf.githubAppPEM,
+    baseUrl: serverConf.githubHost
+  });
+  const jwt = app.getSignedJsonWebToken();
+  const octokit = Octokit({
+    auth: "Bearer " + jwt,
+    userAgent: "octokit/rest.js v1.2.3",
+    baseUrl: serverConf.githubHost,
+    log: {
+      debug: () => {},
+      info: () => {},
+      warn: console.warn,
+      error: console.error
+    }
+  });
+  console.log("--- getRepoInstallation");
+  const installation = await octokit.apps.getRepoInstallation({
+    owner,
+    repo
+  });
+  const installID = installation.data.id;
+  console.log("--- getInstallationAccessToken");
+  const accessToken = await app.getInstallationAccessToken({
+    installationId: installID
+  });
+  return accessToken;
+}
+
 /**
  * findRepoConfig
  * @param {*} owner
@@ -341,3 +372,4 @@ module.exports.createCheckRun = createCheckRun;
 module.exports.updateCheck = updateCheck;
 module.exports.getTagInfo = getTagInfo;
 module.exports.createStampedeCheck = createStampedeCheck;
+module.exports.getAccessToken = getAccessToken;

--- a/scm/github.js
+++ b/scm/github.js
@@ -95,13 +95,11 @@ async function getAccessToken(owner, repo, serverConf) {
       error: console.error
     }
   });
-  console.log("--- getRepoInstallation");
   const installation = await octokit.apps.getRepoInstallation({
     owner,
     repo
   });
   const installID = installation.data.id;
-  console.log("--- getInstallationAccessToken");
   const accessToken = await app.getInstallationAccessToken({
     installationId: installID
   });

--- a/scm/testMode.js
+++ b/scm/testMode.js
@@ -108,9 +108,20 @@ async function createStampedeCheck(
   serverConf
 ) {}
 
+/**
+ * getAccessToken
+ * @param {*} owner
+ * @param {*} repo
+ * @param {*} serverConf
+ */
+async function getAccessToken(owner, repo, serverConf) {
+  return "123456789101112";
+}
+
 module.exports.verifyCredentials = verifyCredentials;
 module.exports.findRepoConfig = findRepoConfig;
 module.exports.createCheckRun = createCheckRun;
 module.exports.getTagInfo = getTagInfo;
 module.exports.updateCheck = updateCheck;
 module.exports.createStampedeCheck = createStampedeCheck;
+module.exports.getAccessToken = getAccessToken;


### PR DESCRIPTION
This PR adds an access token to the scm details that are sent to tasks. This allows tasks to access the GitHub API without having to authenticate themselves. This gives tasks the same permissions that the GitHub App has.