### PR TITLE
🐛 Fixed bug when system overrides was null

### DIFF
--- a/lib/taskDetail.js
+++ b/lib/taskDetail.js
@@ -114,7 +114,11 @@ async function taskConfig(
       source = "orgOverride";
     }
     // System override
-    if (globalOverrides.overrides[key] != null) {
+    if (
+      globalOverrides != null &&
+      globalOverrides.overrides != null &&
+      globalOverrides.overrides[key] != null
+    ) {
       value = globalOverrides.overrides[key];
       source = "systemOverride";
     }


### PR DESCRIPTION
This PR fixes a bug causing task failures if the system overrides list was null.

closes #255 
