### PR TITLE
🐛 expose error when creating check runs

### DIFF
--- a/scm/github.js
+++ b/scm/github.js
@@ -252,6 +252,10 @@ async function createCheckRun(
     .catch(error => {
       console.log(chalk.red("Error creating check run: " + error));
     });
+  if (checkRun.data == null || checkRun.data.id == null) {
+    console.log(chalk.red("Error receiving a check run id. Response was:"));
+    console.dir(checkRun);
+  }
   return checkRun;
 }
 

--- a/scm/github.js
+++ b/scm/github.js
@@ -239,15 +239,19 @@ async function createCheckRun(
   serverConf
 ) {
   const authorizedOctokit = await getAuthorizedOctokit(owner, repo, serverConf);
-  const checkRun = await authorizedOctokit.checks.create({
-    owner: owner,
-    repo: repo,
-    name: taskTitle,
-    head_sha: head_sha,
-    status: "queued",
-    external_id: external_id,
-    started_at: started_at
-  });
+  const checkRun = await authorizedOctokit.checks
+    .create({
+      owner: owner,
+      repo: repo,
+      name: taskTitle,
+      head_sha: head_sha,
+      status: "queued",
+      external_id: external_id,
+      started_at: started_at
+    })
+    .catch(error => {
+      console.log(chalk.red("Error creating check run: " + error));
+    });
   return checkRun;
 }
 


### PR DESCRIPTION
This PR logs any errors received when creating check runs.