### PR TITLE
✨ Admin mode

### DIFF
--- a/bin/stampede-server.js
+++ b/bin/stampede-server.js
@@ -46,7 +46,9 @@ const conf = require("rc")("stampede", {
   scm: "github",
   // Debug assist properties
   logEventPath: null,
-  testModeRepoConfigPath: null
+  testModeRepoConfigPath: null,
+  // Admin mode
+  adminPassword: "stampede"
 });
 
 clear();

--- a/controllers/admin/defaults.js
+++ b/controllers/admin/defaults.js
@@ -6,6 +6,13 @@ function path() {
 }
 
 /**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
  * handle tasks
  * @param {*} req
  * @param {*} res
@@ -28,4 +35,5 @@ async function handle(req, res, dependencies) {
 }
 
 module.exports.path = path;
+module.exports.requiresAdmin = requiresAdmin;
 module.exports.handle = handle;

--- a/controllers/admin/login.js
+++ b/controllers/admin/login.js
@@ -4,14 +4,14 @@ require("pkginfo")(module);
  * path this handler will serve
  */
 function path() {
-  return "/admin/info";
+  return "/admin/login";
 }
 
 /**
  * if the route requires admin
  */
 function requiresAdmin() {
-  return true;
+  return false;
 }
 
 /**
@@ -21,11 +21,9 @@ function requiresAdmin() {
  * @param {*} dependencies
  */
 async function handle(req, res, dependencies) {
-  res.render(dependencies.viewsPath + "admin/info", {
-    version: module.exports.version
-  });
+  res.render(dependencies.viewsPath + "admin/login", {});
 }
 
 module.exports.path = path;
-module.exports.handle = handle;
 module.exports.requiresAdmin = requiresAdmin;
+module.exports.handle = handle;

--- a/controllers/admin/logout.js
+++ b/controllers/admin/logout.js
@@ -4,14 +4,14 @@ require("pkginfo")(module);
  * path this handler will serve
  */
 function path() {
-  return "/admin/info";
+  return "/admin/logout";
 }
 
 /**
  * if the route requires admin
  */
 function requiresAdmin() {
-  return true;
+  return false;
 }
 
 /**
@@ -21,11 +21,11 @@ function requiresAdmin() {
  * @param {*} dependencies
  */
 async function handle(req, res, dependencies) {
-  res.render(dependencies.viewsPath + "admin/info", {
-    version: module.exports.version
-  });
+  res.clearCookie("sSession");
+  res.writeHead(302, { Location: "/" });
+  res.end();
 }
 
 module.exports.path = path;
-module.exports.handle = handle;
 module.exports.requiresAdmin = requiresAdmin;
+module.exports.handle = handle;

--- a/controllers/admin/overrides.js
+++ b/controllers/admin/overrides.js
@@ -6,6 +6,13 @@ function path() {
 }
 
 /**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
  * handle tasks
  * @param {*} req
  * @param {*} res
@@ -28,4 +35,5 @@ async function handle(req, res, dependencies) {
 }
 
 module.exports.path = path;
+module.exports.requiresAdmin = requiresAdmin;
 module.exports.handle = handle;

--- a/controllers/admin/performLogin.js
+++ b/controllers/admin/performLogin.js
@@ -1,10 +1,11 @@
-const yaml = require("js-yaml");
+require("pkginfo")(module);
+const uuidv1 = require("uuid/v1");
 
 /**
  * path this handler will serve
  */
 function path() {
-  return "/repositories/removeOrgConfigDefaults";
+  return "/admin/performLogin";
 }
 
 /**
@@ -18,27 +19,25 @@ function method() {
  * if the route requires admin
  */
 function requiresAdmin() {
-  return true;
+  return false;
 }
 
 /**
- * handle index
+ * handle tasks
  * @param {*} req
  * @param {*} res
  * @param {*} dependencies
  */
 async function handle(req, res, dependencies) {
-  const owner = req.body.owner;
-  const repository = req.body.repository;
-  await dependencies.cache.orgConfigDefaults.removeDefaults(owner);
-  res.writeHead(301, {
-    Location:
-      "/repositories/viewOrgConfigDefaults?owner=" +
-      owner +
-      "&repository=" +
-      repository
-  });
-  res.end();
+  if (req.body.password === dependencies.serverConfig.adminPassword) {
+    const sessionID = uuidv1();
+    res.cookie("sSession", sessionID, { maxAge: 1000 * 60 * 60 * 24 * 30 });
+    res.writeHead(302, { Location: "/" });
+    res.end();
+  } else {
+    res.writeHead(301, { Location: "/admin/login" });
+    res.end();
+  }
 }
 
 module.exports.path = path;

--- a/controllers/admin/queues.js
+++ b/controllers/admin/queues.js
@@ -6,6 +6,13 @@ function path() {
 }
 
 /**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
  * handle tasks
  * @param {*} req
  * @param {*} res
@@ -19,4 +26,5 @@ async function handle(req, res, dependencies) {
 }
 
 module.exports.path = path;
+module.exports.requiresAdmin = requiresAdmin;
 module.exports.handle = handle;

--- a/controllers/admin/removeTask.js
+++ b/controllers/admin/removeTask.js
@@ -8,6 +8,13 @@ function path() {
 }
 
 /**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
  * http method this handler will serve
  */
 function method() {
@@ -31,4 +38,5 @@ async function handle(req, res, dependencies) {
 
 module.exports.path = path;
 module.exports.method = method;
+module.exports.requiresAdmin = requiresAdmin;
 module.exports.handle = handle;

--- a/controllers/admin/taskConfig.js
+++ b/controllers/admin/taskConfig.js
@@ -6,6 +6,13 @@ function path() {
 }
 
 /**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
  * handle tasks
  * @param {*} req
  * @param {*} res
@@ -42,4 +49,5 @@ async function handle(req, res, dependencies) {
 }
 
 module.exports.path = path;
+module.exports.requiresAdmin = requiresAdmin;
 module.exports.handle = handle;

--- a/controllers/admin/tasks.js
+++ b/controllers/admin/tasks.js
@@ -6,6 +6,13 @@ function path() {
 }
 
 /**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
  * handle tasks
  * @param {*} req
  * @param {*} res
@@ -28,4 +35,5 @@ async function handle(req, res, dependencies) {
 }
 
 module.exports.path = path;
+module.exports.requiresAdmin = requiresAdmin;
 module.exports.handle = handle;

--- a/controllers/admin/uploadDefaults.js
+++ b/controllers/admin/uploadDefaults.js
@@ -15,6 +15,13 @@ function method() {
 }
 
 /**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
  * handle uploadDefaults
  * @param {*} req
  * @param {*} res
@@ -46,4 +53,5 @@ async function handle(req, res, dependencies) {
 
 module.exports.path = path;
 module.exports.method = method;
+module.exports.requiresAdmin = requiresAdmin;
 module.exports.handle = handle;

--- a/controllers/admin/uploadOverrides.js
+++ b/controllers/admin/uploadOverrides.js
@@ -15,6 +15,13 @@ function method() {
 }
 
 /**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
  * handle uploadOverrides
  * @param {*} req
  * @param {*} res
@@ -46,4 +53,5 @@ async function handle(req, res, dependencies) {
 
 module.exports.path = path;
 module.exports.method = method;
+module.exports.requiresAdmin = requiresAdmin;
 module.exports.handle = handle;

--- a/controllers/admin/uploadQueues.js
+++ b/controllers/admin/uploadQueues.js
@@ -15,6 +15,13 @@ function method() {
 }
 
 /**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
  * handle tasks
  * @param {*} req
  * @param {*} res
@@ -37,4 +44,5 @@ async function handle(req, res, dependencies) {
 
 module.exports.path = path;
 module.exports.method = method;
+module.exports.requiresAdmin = requiresAdmin;
 module.exports.handle = handle;

--- a/controllers/admin/uploadTask.js
+++ b/controllers/admin/uploadTask.js
@@ -15,6 +15,13 @@ function method() {
 }
 
 /**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
  * handle tasks
  * @param {*} req
  * @param {*} res
@@ -40,4 +47,5 @@ async function handle(req, res, dependencies) {
 
 module.exports.path = path;
 module.exports.method = method;
+module.exports.requiresAdmin = requiresAdmin;
 module.exports.handle = handle;

--- a/controllers/index.js
+++ b/controllers/index.js
@@ -6,6 +6,13 @@ function path() {
 }
 
 /**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return false;
+}
+
+/**
  * handle index
  * @param {*} req
  * @param {*} res
@@ -16,4 +23,5 @@ async function handle(req, res, dependencies) {
 }
 
 module.exports.path = path;
+module.exports.requiresAdmin = requiresAdmin;
 module.exports.handle = handle;

--- a/controllers/repositories/removeOrgConfigOverrides.js
+++ b/controllers/repositories/removeOrgConfigOverrides.js
@@ -15,6 +15,13 @@ function method() {
 }
 
 /**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
  * handle index
  * @param {*} req
  * @param {*} res
@@ -36,4 +43,5 @@ async function handle(req, res, dependencies) {
 
 module.exports.path = path;
 module.exports.method = method;
+module.exports.requiresAdmin = requiresAdmin;
 module.exports.handle = handle;

--- a/controllers/repositories/removeRepoConfigDefaults.js
+++ b/controllers/repositories/removeRepoConfigDefaults.js
@@ -15,6 +15,13 @@ function method() {
 }
 
 /**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
  * handle index
  * @param {*} req
  * @param {*} res
@@ -36,4 +43,5 @@ async function handle(req, res, dependencies) {
 
 module.exports.path = path;
 module.exports.method = method;
+module.exports.requiresAdmin = requiresAdmin;
 module.exports.handle = handle;

--- a/controllers/repositories/removeRepoConfigOverrides.js
+++ b/controllers/repositories/removeRepoConfigOverrides.js
@@ -15,6 +15,13 @@ function method() {
 }
 
 /**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
  * handle index
  * @param {*} req
  * @param {*} res
@@ -39,4 +46,5 @@ async function handle(req, res, dependencies) {
 
 module.exports.path = path;
 module.exports.method = method;
+module.exports.requiresAdmin = requiresAdmin;
 module.exports.handle = handle;

--- a/controllers/repositories/removeRepositoryBuild.js
+++ b/controllers/repositories/removeRepositoryBuild.js
@@ -8,6 +8,13 @@ function path() {
 }
 
 /**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
  * handle index
  * @param {*} req
  * @param {*} res
@@ -35,4 +42,5 @@ async function handle(req, res, dependencies) {
 }
 
 module.exports.path = path;
+module.exports.requiresAdmin = requiresAdmin;
 module.exports.handle = handle;

--- a/controllers/repositories/selectConfigSource.js
+++ b/controllers/repositories/selectConfigSource.js
@@ -6,6 +6,13 @@ function path() {
 }
 
 /**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
  * handle index
  * @param {*} req
  * @param {*} res
@@ -22,4 +29,5 @@ async function handle(req, res, dependencies) {
 }
 
 module.exports.path = path;
+module.exports.requiresAdmin = requiresAdmin;
 module.exports.handle = handle;

--- a/controllers/repositories/toggleConfigSource.js
+++ b/controllers/repositories/toggleConfigSource.js
@@ -6,6 +6,13 @@ function path() {
 }
 
 /**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
  * handle index
  * @param {*} req
  * @param {*} res
@@ -33,4 +40,5 @@ async function handle(req, res, dependencies) {
 }
 
 module.exports.path = path;
+module.exports.requiresAdmin = requiresAdmin;
 module.exports.handle = handle;

--- a/controllers/repositories/uploadOrgConfigDefaults.js
+++ b/controllers/repositories/uploadOrgConfigDefaults.js
@@ -15,6 +15,13 @@ function method() {
 }
 
 /**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
  * handle index
  * @param {*} req
  * @param {*} res
@@ -43,4 +50,5 @@ async function handle(req, res, dependencies) {
 
 module.exports.path = path;
 module.exports.method = method;
+module.exports.requiresAdmin = requiresAdmin;
 module.exports.handle = handle;

--- a/controllers/repositories/uploadOrgConfigOverrides.js
+++ b/controllers/repositories/uploadOrgConfigOverrides.js
@@ -15,6 +15,13 @@ function method() {
 }
 
 /**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
  * handle index
  * @param {*} req
  * @param {*} res
@@ -46,4 +53,5 @@ async function handle(req, res, dependencies) {
 
 module.exports.path = path;
 module.exports.method = method;
+module.exports.requiresAdmin = requiresAdmin;
 module.exports.handle = handle;

--- a/controllers/repositories/uploadRepoConfigDefaults.js
+++ b/controllers/repositories/uploadRepoConfigDefaults.js
@@ -15,6 +15,13 @@ function method() {
 }
 
 /**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
  * handle index
  * @param {*} req
  * @param {*} res
@@ -47,4 +54,5 @@ async function handle(req, res, dependencies) {
 
 module.exports.path = path;
 module.exports.method = method;
+module.exports.requiresAdmin = requiresAdmin;
 module.exports.handle = handle;

--- a/controllers/repositories/uploadRepoConfigOverrides.js
+++ b/controllers/repositories/uploadRepoConfigOverrides.js
@@ -15,6 +15,13 @@ function method() {
 }
 
 /**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
  * handle index
  * @param {*} req
  * @param {*} res
@@ -47,4 +54,5 @@ async function handle(req, res, dependencies) {
 
 module.exports.path = path;
 module.exports.method = method;
+module.exports.requiresAdmin = requiresAdmin;
 module.exports.handle = handle;

--- a/controllers/repositories/uploadRepositoryBuild.js
+++ b/controllers/repositories/uploadRepositoryBuild.js
@@ -15,6 +15,13 @@ function method() {
 }
 
 /**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
  * handle index
  * @param {*} req
  * @param {*} res
@@ -47,4 +54,5 @@ async function handle(req, res, dependencies) {
 
 module.exports.path = path;
 module.exports.method = method;
+module.exports.requiresAdmin = requiresAdmin;
 module.exports.handle = handle;

--- a/controllers/repositories/uploadRepositoryConfig.js
+++ b/controllers/repositories/uploadRepositoryConfig.js
@@ -15,6 +15,13 @@ function method() {
 }
 
 /**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
  * handle index
  * @param {*} req
  * @param {*} res
@@ -43,4 +50,5 @@ async function handle(req, res, dependencies) {
 
 module.exports.path = path;
 module.exports.method = method;
+module.exports.requiresAdmin = requiresAdmin;
 module.exports.handle = handle;

--- a/controllers/repositories/viewCachedConfig.js
+++ b/controllers/repositories/viewCachedConfig.js
@@ -8,6 +8,13 @@ function path() {
 }
 
 /**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
  * handle index
  * @param {*} req
  * @param {*} res
@@ -31,4 +38,5 @@ async function handle(req, res, dependencies) {
 }
 
 module.exports.path = path;
+module.exports.requiresAdmin = requiresAdmin;
 module.exports.handle = handle;

--- a/controllers/repositories/viewOrgConfigDefaults.js
+++ b/controllers/repositories/viewOrgConfigDefaults.js
@@ -8,6 +8,13 @@ function path() {
 }
 
 /**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
  * handle index
  * @param {*} req
  * @param {*} res
@@ -36,4 +43,5 @@ async function handle(req, res, dependencies) {
 }
 
 module.exports.path = path;
+module.exports.requiresAdmin = requiresAdmin;
 module.exports.handle = handle;

--- a/controllers/repositories/viewOrgConfigOverrides.js
+++ b/controllers/repositories/viewOrgConfigOverrides.js
@@ -8,6 +8,13 @@ function path() {
 }
 
 /**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
  * handle index
  * @param {*} req
  * @param {*} res
@@ -36,4 +43,5 @@ async function handle(req, res, dependencies) {
 }
 
 module.exports.path = path;
+module.exports.requiresAdmin = requiresAdmin;
 module.exports.handle = handle;

--- a/controllers/repositories/viewRepoConfigDefaults.js
+++ b/controllers/repositories/viewRepoConfigDefaults.js
@@ -8,6 +8,13 @@ function path() {
 }
 
 /**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
  * handle index
  * @param {*} req
  * @param {*} res
@@ -37,4 +44,5 @@ async function handle(req, res, dependencies) {
 }
 
 module.exports.path = path;
+module.exports.requiresAdmin = requiresAdmin;
 module.exports.handle = handle;

--- a/controllers/repositories/viewRepoConfigOverrides.js
+++ b/controllers/repositories/viewRepoConfigOverrides.js
@@ -8,6 +8,13 @@ function path() {
 }
 
 /**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
  * handle index
  * @param {*} req
  * @param {*} res
@@ -37,4 +44,5 @@ async function handle(req, res, dependencies) {
 }
 
 module.exports.path = path;
+module.exports.requiresAdmin = requiresAdmin;
 module.exports.handle = handle;

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -25,11 +25,41 @@ function router(dependencies) {
         console.log(chalk.green("UI [" + method + "] " + path));
         if (method === "get") {
           basicRouter.get(path, function(req, res) {
-            handler.handle(req, res, dependencies);
+            const sessionID = req.cookies["sSession"];
+            let hasValidAdminSession = false;
+            if (sessionID != null) {
+              hasValidAdminSession = true;
+            }
+            req.validAdminSession = hasValidAdminSession;
+            if (
+              handler.requiresAdmin == null ||
+              !handler.requiresAdmin() ||
+              (handler.requiresAdmin() && hasValidAdminSession)
+            ) {
+              handler.handle(req, res, dependencies);
+            } else {
+              res.writeHead(302, { Location: "/admin/login" });
+              res.end();
+            }
           });
         } else if (method === "post") {
           basicRouter.post(path, function(req, res) {
-            handler.handle(req, res, dependencies);
+            const sessionID = req.cookies["sSession"];
+            let hasValidAdminSession = false;
+            if (sessionID != null) {
+              hasValidAdminSession = true;
+            }
+            req.validAdminSession = hasValidAdminSession;
+            if (
+              handler.requiresAdmin == null ||
+              !handler.requiresAdmin() ||
+              (handler.requiresAdmin() && hasValidAdminSession)
+            ) {
+              handler.handle(req, res, dependencies);
+            } else {
+              res.writeHead(302, { Location: "/admin/login" });
+              res.end();
+            }
           });
         }
       }

--- a/lib/web.js
+++ b/lib/web.js
@@ -2,6 +2,7 @@
 let express = require("express");
 const chalk = require("chalk");
 const fileUpload = require("express-fileupload");
+const cookieParser = require("cookie-parser");
 
 // Routers
 const api = require("./api");
@@ -14,6 +15,7 @@ let bodyParser = require("body-parser");
 app.use(morgan("dev"));
 app.use(bodyParser.json({ limit: "50mb" }));
 app.use(bodyParser.urlencoded({ extended: true }));
+app.use(cookieParser());
 app.use(express.static(__dirname + "/../public"));
 app.set("view engine", "pug");
 app.use(fileUpload());

--- a/views/admin/login.pug
+++ b/views/admin/login.pug
@@ -1,0 +1,22 @@
+extends ../layout
+
+include ../components/titleBar
+include ../components/tableHeader
+include ../components/tableCell
+include ../components/tableRow
+
+block content
+
+  div(class="w-full p-3")
+    div(class="bg-white border-transparent rounded-lg shadow-lg")
+      div(class="bg-gray-400 uppercase text-gray-800 border-b-2 border-gray-500 rounded-tl-lg rounded-tr-lg p-2")
+        h5(class="font-bold uppercase text-gray-600") Admin access is required for the page you selected:
+      div(class="p-5")
+        form(class="w-full m-4" method="POST" action="/admin/performLogin" encType="multipart/form-data")
+          div(class="flex -mx-3 mb-6")
+            div(class="w-1/2 px-3 mb-6 md:mb-0")
+              label(for="searchValue")= `Admin Password`
+            input(type="password", class="form-control", id="password", name="password", aria-describedby="passwordHelp", placeholder="Password")
+          div(class="w-1/2 px-3 mb-6 md:mb-0")
+            button(class="bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded") Login
+            

--- a/views/components/sideBar.pug
+++ b/views/components/sideBar.pug
@@ -26,5 +26,6 @@ mixin sideBar(activeMenu)
                     {title: 'Defaults', href: '/admin/defaults'},
                     {title: 'Overrides', href: '/admin/overrides'},
                     {title: 'Queues', href: '/admin/queues'},
-                    {title: 'Info', href: '/admin/info'}
+                    {title: 'Info', href: '/admin/info'},
+                    {title: 'Logout', href: '/admin/logout'}
                     ])


### PR DESCRIPTION
This PR introduces a basic admin mode. This requires users to login using an admin password before they can access admin specific features. Mostly this revolves around changing any of the task or build configs. Normal users can view builds and look at history.

closes #211 
