### PR TITLE
♻️ Removed additional PR details from task scm info

### DIFF
--- a/controllers/repositories/executeTask.js
+++ b/controllers/repositories/executeTask.js
@@ -40,10 +40,6 @@ async function handle(req, res, dependencies) {
   if (req.body.buildType === "Pull Request") {
     scmConfig.pullRequest = {
       number: req.body["pr number"],
-      title: req.body["pr title"],
-      bodyLength: req.body["pr body length"],
-      milestone: req.body["pr milestone"],
-      labels: req.body["pr labels"].split(","),
       head: {
         ref: req.body["head ref"],
         sha: req.body["head sha"]

--- a/controllers/repositories/executeTaskConfig.js
+++ b/controllers/repositories/executeTaskConfig.js
@@ -70,22 +70,6 @@ async function handle(req, res, dependencies) {
       value: providedScm.prNumber != null ? providedScm.prNumber : ""
     });
     scm.push({
-      key: "pr title",
-      value: providedScm.prTitle != null ? providedScm.prTitle : ""
-    });
-    scm.push({
-      key: "pr body length",
-      value: providedScm.prBodyLength != null ? providedScm.prBodyLength : ""
-    });
-    scm.push({
-      key: "pr milestone",
-      value: providedScm.prMilestone != null ? providedScm.prMilestone : ""
-    });
-    scm.push({
-      key: "pr labels",
-      value: providedScm.prLabels != null ? providedScm.prLabels : ""
-    });
-    scm.push({
       key: "head ref",
       value: providedScm.headRef != null ? providedScm.headRef : ""
     });

--- a/events/pullRequest.js
+++ b/events/pullRequest.js
@@ -144,10 +144,6 @@ async function pullRequestEdit(
 
   const pullRequestDetails = {
     number: pullRequest.number,
-    title: pullRequest.title,
-    bodyLength: pullRequest.body.length,
-    milestone: pullRequest.milestone != null ? pullRequest.milestone.title : "",
-    labels: pullRequest.labels.map(label => label.name),
     head: {
       ref: pullRequest.head.ref,
       sha: pullRequest.head.sha

--- a/lib/checkRun.js
+++ b/lib/checkRun.js
@@ -69,10 +69,6 @@ async function createCheckRun(
 
   const pullRequestDetails = {
     number: pullRequest.number,
-    title: pullRequest.title,
-    bodyLength: pullRequest.body.length,
-    milestone: pullRequest.milestone != null ? pullRequest.milestone.title : "",
-    labels: pullRequest.labels.map(label => label.name),
     head: {
       ref: pullRequest.head.ref,
       sha: sha
@@ -191,10 +187,6 @@ async function createCheckRunForAction(
 
   const pullRequestDetails = {
     number: pullRequest.number,
-    title: pullRequest.title,
-    bodyLength: pullRequest.body.length,
-    milestone: pullRequest.milestone != null ? pullRequest.milestone.title : "",
-    labels: pullRequest.labels.map(label => label.name),
     head: {
       ref: pullRequest.head.ref,
       sha: sha


### PR DESCRIPTION
This PR removes some additional PR details that were added to the task info. These aren't provided by all the GitHub events, so it would be better to make the tasks fetch them if they are needed rather than making the server do it.

closes #269 