### PR TITLE
🐛 Fixed logic bug in scheduler

### DIFF
--- a/bin/stampede-server.js
+++ b/bin/stampede-server.js
@@ -206,13 +206,14 @@ async function buildSchedule() {
           repositoryBuilds[buildIndex]
         );
         if (
-          (buildInfo.schedule != null && buildInfo.lastExecuteDate == null) ||
-          new Date(buildInfo.lastExecuteDate).getDate() !=
-            currentDate.getDate() ||
-          new Date(buildInfo.lastExecuteDate).getMonth() !=
-            currentDate.getMonth() ||
-          new Date(buildInfo.lastExecuteDate).getFullYear() !=
-            currentDate.getFullYear()
+          buildInfo.schedule != null &&
+          (buildInfo.lastExecuteDate == null ||
+            new Date(buildInfo.lastExecuteDate).getDate() !=
+              currentDate.getDate() ||
+            new Date(buildInfo.lastExecuteDate).getMonth() !=
+              currentDate.getMonth() ||
+            new Date(buildInfo.lastExecuteDate).getFullYear() !=
+              currentDate.getFullYear())
         ) {
           if (
             currentDate.getHours() >= buildInfo.schedule.hour &&


### PR DESCRIPTION
This PR fixes a bug in the server where the scheduler would error out if a build didn't have a schedule, such as a manual build.

closes #273 