### PR TITLE
🐛 Sanitized params in release name

### DIFF
--- a/events/release.js
+++ b/events/release.js
@@ -155,7 +155,9 @@ function parseEvent(req) {
  */
 function safeBuildKey(release) {
   const spacesRemoved = release.replace(/ /g, "_");
-  return sanitize(spacesRemoved);
+  const openParamRemoved = spacesRemoved.replace(/\(/g, "_");
+  const closedParamRemoved = openParamRemoved.replace(/\)/g, "_");
+  return sanitize(closedParamRemoved);
 }
 
 module.exports.handle = handle;


### PR DESCRIPTION
This PR fixes an issue caused by params in the release title.

closes #280 