### PR TITLE
✨ Now sending GitHub release body text to the task

### DIFF
--- a/events/release.js
+++ b/events/release.js
@@ -101,7 +101,8 @@ async function handle(req, serverConf, cache, scm, db, logger) {
     release: {
       name: event.release,
       tag: event.tag,
-      sha: sha
+      sha: sha,
+      body: event.body
     }
   };
 
@@ -142,6 +143,7 @@ function parseEvent(req) {
     cloneURL: req.body.repository.clone_url,
     sshURL: req.body.repository.ssh_url,
     prerelease: req.body.release.prerelease,
+    body: req.body.release.body,
     draft: req.body.release.draft,
     target: req.body.release.target_commitish
   };


### PR DESCRIPTION
This PR adds the GitHub Release body text to the details sent to tasks. This can be used to take release notes entered into GitHub and display them on deployed apps. Or to append additional info back into the release text.

closes #282 