### PR TITLE
♻️Added execute build confirmation screen

### DIFF
--- a/controllers/repositories/executeRepositoryBuild.js
+++ b/controllers/repositories/executeRepositoryBuild.js
@@ -27,16 +27,10 @@ async function handle(req, res, dependencies) {
 
   repositoryBuild.execute(owner, repository, buildID, buildInfo, dependencies);
 
-  res.writeHead(301, {
-    Location:
-      "/repositories/repositoryBuildDetails?owner=" +
-      owner +
-      "&repository=" +
-      repository +
-      "&build=" +
-      buildID
+  res.render(dependencies.viewsPath + "repositories/executeRepositoryBuild", {
+    owner: owner,
+    repository: repository
   });
-  res.end();
 }
 
 module.exports.path = path;

--- a/views/repositories/executeRepositoryBuild.pug
+++ b/views/repositories/executeRepositoryBuild.pug
@@ -1,0 +1,22 @@
+extends ../layout
+include ../components/titleBar
+include ../components/tableHeader
+include ../components/tableCell
+include ../components/tableRow
+include ../components/tableCellButton
+include ../components/formSelect
+include ../components/formInput
+include ../components/formHidden
+
+block content
+
+  +titleBar([{title: 'Repositories', href: '/repositories'},
+  {title: owner + ' ' + repository, href: '/repositories/repositoryDetails?owner=' + owner + '&repository=' + repository},
+  {title: "Execute Build Confirmation"}])
+  div(class="flex flex-wrap m-4")
+
+    p Build submitted for execution. Return to the repository details page and you will find the build under Active Builds.
+    h3(class="font-bold pl-2 underline")
+      a(href='/repositories/repositoryDetails?owner=' + owner + '&repository=' + repository)= `Repository Details Page` 
+
+    


### PR DESCRIPTION
This PR adds a confirmation screen to the repository build execution. This gives details and a link to the Repository Details page to make it clear that users should go back to that page to see their build under Active Build. This is instead of a popup message per #279 but it should solve the root problem of starting a build but not knowing you did.

closes #279 