### PR TITLE
🐛 Remove attempt to create stampede check if we are not in a pr build

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -77,15 +77,17 @@ async function startBuild(
     buildDetails
   );
 
-  // Create the general Stampede Build Check
-  scm.createStampedeCheck(
-    buildDetails.owner,
-    buildDetails.repo,
-    buildDetails.sha,
-    buildDetails.buildPath + "-" + buildDetails.buildNumber,
-    actions,
-    serverConf
-  );
+  // Create the general Stampede Build Check only for pull requests
+  if (scmDetails.pullRequest != null) {
+    scm.createStampedeCheck(
+      buildDetails.owner,
+      buildDetails.repo,
+      buildDetails.sha,
+      buildDetails.buildPath + "-" + buildDetails.buildNumber,
+      actions,
+      serverConf
+    );
+  }
 
   task.startTasks(
     buildDetails.owner,

--- a/scm/testMode.js
+++ b/scm/testMode.js
@@ -107,7 +107,9 @@ async function createStampedeCheck(
   buildKey,
   actions,
   serverConf
-) {}
+) {
+  systemLogger.verbose("createStampedeCheck");
+}
 
 /**
  * getAccessToken


### PR DESCRIPTION
This PR removes the attempt to create a stampede check when the build starts. For non-PR builds this will fail anyway since we don't have checks on non-PRs in GitHub. Now the check is never attempted, saving an error message from the logs.

closes #283 