### PR TITLE
🐛 Fixed issue with empty notification queue list

### DIFF
--- a/bin/stampede-server.js
+++ b/bin/stampede-server.js
@@ -121,7 +121,11 @@ taskQueue.setRedisConfig(redisConfig);
 
 // Setup the notification queue(s)
 notification.setRedisConfig(redisConfig);
-notification.setNotificationQueues(conf.notificationQueues.split(","));
+if (conf.notificationQueues != null && conf.notificationQueues.length > 0) {
+  notification.setNotificationQueues(conf.notificationQueues.split(","));
+} else {
+  notification.setNotificationQueues([]);
+}
 
 // Setup our scm based on what is configured
 let scm = {};


### PR DESCRIPTION
This PR fixes an issue where the server was sending notifications to an empty queue name. This was leaving unprocessed messages in redis.

closes #288 