### PR TITLE
✨Added task history to api

### DIFF
--- a/api/history/tasks.js
+++ b/api/history/tasks.js
@@ -1,0 +1,59 @@
+"use strict";
+
+/**
+ * The url path this handler will serve
+ */
+function path() {
+  return "/api/history/tasks";
+}
+
+/**
+ * handle
+ * @param {*} req
+ * @param {*} res
+ * @param {*} dependencies
+ */
+async function handle(req, res, dependencies) {
+  let timeFilter = "Last 8 hours";
+  if (req.query.time != null) {
+    timeFilter = req.query.time;
+  }
+
+  let taskFilter = "All";
+  if (req.query.task != null) {
+    taskFilter = req.query.task;
+  }
+
+  let repositoryFilter = "All";
+  if (req.query.repository != null) {
+    repositoryFilter = req.query.repository;
+  }
+
+  let conclusionFilter = "All";
+  if (req.query.conclusion != null) {
+    conclusionFilter = req.query.conclusion;
+  }
+
+  let sorted = "Date DESC";
+  if (req.query.sorted != null) {
+    sorted = req.query.sorted;
+  }
+
+  let nodeFilter = "All";
+  if (req.query.node != null) {
+    nodeFilter = req.query.node;
+  }
+
+  const tasks = await dependencies.db.recentTasks(
+    timeFilter,
+    taskFilter,
+    repositoryFilter,
+    conclusionFilter,
+    nodeFilter,
+    sorted
+  );
+  res.send(tasks.rows);
+}
+
+module.exports.path = path;
+module.exports.handle = handle;


### PR DESCRIPTION
This PR adds a new API endpoint `/api/history/tasks` which will return a list of the recent tasks. It accepts filters for time range, repository, status and node.

closes #290 