### PR TITLE
🐛 PR task actions now are uniquely identified

### DIFF
--- a/lib/checkRun.js
+++ b/lib/checkRun.js
@@ -216,12 +216,17 @@ async function createCheckRunForAction(
     buildDetails.owner + "-" + buildDetails.repo + "-" + buildDetails.buildKey;
   const buildConfig = repoConfig.pullrequests;
 
-  task.startTasks(
+  const buildID = buildPath + "-" + buildNumber;
+  const buildTasks = await db.fetchBuildTasks(buildID);
+  const taskNumber = buildTasks.rows.length + 1;
+
+  task.startSingleTask(
     buildDetails.owner,
     buildDetails.repo,
     buildDetails.buildKey,
     buildDetails.sha,
-    [action],
+    action,
+    taskNumber,
     buildPath,
     buildNumber,
     scm,

--- a/lib/task.js
+++ b/lib/task.js
@@ -78,6 +78,71 @@ async function startTasks(
 }
 
 /**
+ * Start a single task
+ * @param {*} owner
+ * @param {*} repo
+ * @param {*} buildKey
+ * @param {*} sha
+ * @param {*} task
+ * @param {*} taskNumber
+ * @param {*} buildPath
+ * @param {*} buildNumber
+ * @param {*} scm
+ * @param {*} scmDetails
+ * @param {*} overrideTaskQueue
+ * @param {*} cache
+ * @param {*} repoConfig
+ * @param {*} buildConfig
+ * @param {*} serverConf
+ * @param {*} db
+ * @param {*} logger
+ */
+async function startSingleTask(
+  owner,
+  repo,
+  buildKey,
+  sha,
+  task,
+  taskNumber,
+  buildPath,
+  buildNumber,
+  scm,
+  scmDetails,
+  overrideTaskQueue,
+  cache,
+  repoConfig,
+  buildConfig,
+  serverConf,
+  db,
+  logger
+) {
+  // Add the main tasks to the active list before we perform other tasks so that
+  // as notifications come back in we know if the build is finished or not.
+  await addTaskToActiveList(buildPath, buildNumber, task, taskNumber, cache);
+
+  // Start our main tasks
+  await startTask(
+    owner,
+    repo,
+    buildKey,
+    sha,
+    task,
+    taskNumber,
+    buildPath,
+    buildNumber,
+    scm,
+    scmDetails,
+    overrideTaskQueue,
+    cache,
+    repoConfig,
+    buildConfig,
+    serverConf,
+    db,
+    logger
+  );
+}
+
+/**
  * addTaskToActiveList
  * @param {*} buildPath
  * @param {*} buildNumber
@@ -229,3 +294,4 @@ async function startTask(
 }
 
 module.exports.startTasks = startTasks;
+module.exports.startSingleTask = startSingleTask;


### PR DESCRIPTION
This PR adjusts how PR actions are treated. Instead of creating a new build, now they are appending to the existing build with a unique task ID. Before the task ID would be the same for every execution. This can cause issues on the worker since it tries to clone to the same working folder. Also the Task ID can now be depended on to be unique if needed for publishing artifacts or other needs.

closes #300
