### PR TITLE
📝 Changed title of Stampede check

### DIFF
--- a/scm/github.js
+++ b/scm/github.js
@@ -364,7 +364,7 @@ async function createStampedeCheck(
   const checkRun = await authorizedOctokit.checks.create({
     owner: owner,
     repo: repo,
-    name: "Stampede Build",
+    name: "Stampede Information",
     head_sha: head_sha,
     status: "completed",
     external_id: externalID,
@@ -372,7 +372,7 @@ async function createStampedeCheck(
     completed_at: new Date(),
     conclusion: "neutral",
     output: {
-      title: "Stampede Build",
+      title: "Stampede Information",
       summary: welcomeString,
       text: ""
     },


### PR DESCRIPTION
This PR changes the title of the Stampede check. Eventually it should probably be configurable, but for now it will be titled `Stampede Information`.