### PR TITLE
✨ Hiding task config for non admins

### DIFF
--- a/controllers/history/buildTaskDetails.js
+++ b/controllers/history/buildTaskDetails.js
@@ -20,15 +20,17 @@ async function handle(req, res, dependencies, owners) {
     );
     const taskDetails = detailsRows.rows[0];
     const configValues = [];
-    Object.keys(
-      taskDetails.details.config != null ? taskDetails.details.config : {}
-    ).forEach(function (key) {
-      configValues.push({
-        key: key,
-        value: taskDetails.details.config[key].value,
-        source: taskDetails.details.config[key].source,
+    if (req.validAdminSession == true) {
+      Object.keys(
+        taskDetails.details.config != null ? taskDetails.details.config : {}
+      ).forEach(function (key) {
+        configValues.push({
+          key: key,
+          value: taskDetails.details.config[key].value,
+          source: taskDetails.details.config[key].source,
+        });
       });
-    });
+    }
     const buildRows = await dependencies.db.fetchBuild(task.build_id);
     const build = buildRows.rows[0];
     res.render(dependencies.viewsPath + "history/buildTaskDetails", {

--- a/controllers/history/taskDetails.js
+++ b/controllers/history/taskDetails.js
@@ -17,15 +17,17 @@ async function handle(req, res, dependencies, owners) {
   const detailsRows = await dependencies.db.fetchTaskDetails(req.query.taskID);
   const taskDetails = detailsRows.rows[0];
   const configValues = [];
-  Object.keys(
-    taskDetails.details.config != null ? taskDetails.details.config : {}
-  ).forEach(function (key) {
-    configValues.push({
-      key: key,
-      value: taskDetails.details.config[key].value,
-      source: taskDetails.details.config[key].source,
+  if (req.validAdminSession == true) {
+    Object.keys(
+      taskDetails.details.config != null ? taskDetails.details.config : {}
+    ).forEach(function (key) {
+      configValues.push({
+        key: key,
+        value: taskDetails.details.config[key].value,
+        source: taskDetails.details.config[key].source,
+      });
     });
-  });
+  }
   const buildRows = await dependencies.db.fetchBuild(task.build_id);
   const build = buildRows.rows[0];
   const summary =

--- a/controllers/monitor/buildTaskDetails.js
+++ b/controllers/monitor/buildTaskDetails.js
@@ -20,15 +20,17 @@ async function handle(req, res, dependencies, owners) {
     );
     const taskDetails = detailsRows.rows[0];
     const configValues = [];
-    Object.keys(
-      taskDetails.details.config != null ? taskDetails.details.config : {}
-    ).forEach(function (key) {
-      configValues.push({
-        key: key,
-        value: taskDetails.details.config[key].value,
-        source: taskDetails.details.config[key].source,
+    if (req.validAdminSession == true) {
+      Object.keys(
+        taskDetails.details.config != null ? taskDetails.details.config : {}
+      ).forEach(function (key) {
+        configValues.push({
+          key: key,
+          value: taskDetails.details.config[key].value,
+          source: taskDetails.details.config[key].source,
+        });
       });
-    });
+    }
     const buildRows = await dependencies.db.fetchBuild(task.build_id);
     const build = buildRows.rows[0];
     const summary =

--- a/controllers/repositories/taskDetails.js
+++ b/controllers/repositories/taskDetails.js
@@ -17,15 +17,17 @@ async function handle(req, res, dependencies, owners) {
   const detailsRows = await dependencies.db.fetchTaskDetails(req.query.taskID);
   const taskDetails = detailsRows.rows[0];
   const configValues = [];
-  Object.keys(
-    taskDetails.details.config != null ? taskDetails.details.config : {}
-  ).forEach(function (key) {
-    configValues.push({
-      key: key,
-      value: taskDetails.details.config[key].value,
-      source: taskDetails.details.config[key].source,
+  if (req.validAdminSession == true) {
+    Object.keys(
+      taskDetails.details.config != null ? taskDetails.details.config : {}
+    ).forEach(function (key) {
+      configValues.push({
+        key: key,
+        value: taskDetails.details.config[key].value,
+        source: taskDetails.details.config[key].source,
+      });
     });
-  });
+  }
   const buildRows = await dependencies.db.fetchBuild(task.build_id);
   const build = buildRows.rows[0];
   const summary =

--- a/views/history/buildTaskDetails.pug
+++ b/views/history/buildTaskDetails.pug
@@ -26,19 +26,19 @@ block content
                 +tableCell('Node')
                 +tableCell(task.node)
 
-    +infoCard('Task Config')
-        table(class="table-auto w-full")
-            thead
-              +tableHeader('Config Parameter')
-              +tableHeader('Source')
-              +tableHeader('Value')
-            tbody
-                each config, i in configValues
-                    +tableRow()
-                        +tableCell(config.key)
-                        +tableCell(config.source)
-                        +tableCell(config.value)
-
+    if configValues.length > 0
+      +infoCard('Task Config')
+          table(class="table-auto w-full")
+              thead
+                +tableHeader('Config Parameter')
+                +tableHeader('Source')
+                +tableHeader('Value')
+              tbody
+                  each config, i in configValues
+                      +tableRow()
+                          +tableCell(config.key)
+                          +tableCell(config.source)
+                          +tableCell(config.value)
 
     if taskDetails.details.result
         +infoCard('Task Results')

--- a/views/history/taskDetails.pug
+++ b/views/history/taskDetails.pug
@@ -51,19 +51,19 @@ block content
               +tableCell('Started At')
               +tableCell(build.started_at)
 
-    +infoCard('Task Config')
-        table(class="table-auto w-full")
-            thead
-              +tableHeader('Config Parameter')
-              +tableHeader('Source')
-              +tableHeader('Value')
-            tbody
-                each config, i in configValues
-                    +tableRow()
-                        +tableCell(config.key)
-                        +tableCell(config.source)
-                        +tableCell(config.value)
-
+    if configValues.length > 0
+      +infoCard('Task Config')
+          table(class="table-auto w-full")
+              thead
+                +tableHeader('Config Parameter')
+                +tableHeader('Source')
+                +tableHeader('Value')
+              tbody
+                  each config, i in configValues
+                      +tableRow()
+                          +tableCell(config.key)
+                          +tableCell(config.source)
+                          +tableCell(config.value)
 
     if taskDetails.details.result
         +infoCard('Task Results')

--- a/views/monitor/buildTaskDetails.pug
+++ b/views/monitor/buildTaskDetails.pug
@@ -29,19 +29,19 @@ block content
                 +tableCellButton('Cancel', '/monitor/cancelTask?taskID=' + task.task_id)
                 +tableCell('')
 
-    +infoCard('Task Config')
-        table(class="table-auto w-full")
-            thead
-              +tableHeader('Config Parameter')
-              +tableHeader('Source')
-              +tableHeader('Value')
-            tbody
-                each config, i in configValues
-                    +tableRow()
-                        +tableCell(config.key)
-                        +tableCell(config.source)
-                        +tableCell(config.value)
-
+    if configValues.length > 0
+      +infoCard('Task Config')
+          table(class="table-auto w-full")
+              thead
+                +tableHeader('Config Parameter')
+                +tableHeader('Source')
+                +tableHeader('Value')
+              tbody
+                  each config, i in configValues
+                      +tableRow()
+                          +tableCell(config.key)
+                          +tableCell(config.source)
+                          +tableCell(config.value)
 
     if taskDetails.details.result
         +infoCard('Task Results')

--- a/views/repositories/taskDetails.pug
+++ b/views/repositories/taskDetails.pug
@@ -27,19 +27,19 @@ block content
                 +tableCell('Node')
                 +tableCell(task.node)
 
-    +infoCard('Task Config')
-        table(class="table-auto w-full")
-            thead
-              +tableHeader('Config Parameter')
-              +tableHeader('Source')
-              +tableHeader('Value')
-            tbody
-                each config, i in configValues
-                    +tableRow()
-                        +tableCell(config.key)
-                        +tableCell(config.source)
-                        +tableCell(config.value)
-
+    if configValues.length > 0
+      +infoCard('Task Config')
+          table(class="table-auto w-full")
+              thead
+                +tableHeader('Config Parameter')
+                +tableHeader('Source')
+                +tableHeader('Value')
+              tbody
+                  each config, i in configValues
+                      +tableRow()
+                          +tableCell(config.key)
+                          +tableCell(config.source)
+                          +tableCell(config.value)
 
     if taskDetails.details.result
         +infoCard('Task Results')


### PR DESCRIPTION
This PR hides the task config section for non-admins. This cleans up the task details a bit since most users don't need to see all the task config items. Once we add some fields to the task config to indicate which fields are secure, we can relax this restriction so that non-admins will see the config for non-secure items.

closes #317 