### PR TITLE
✨ Admins can now add repositories

### DIFF
--- a/controllers/admin/addRepository.js
+++ b/controllers/admin/addRepository.js
@@ -1,0 +1,34 @@
+/**
+ * path this handler will serve
+ */
+function path() {
+  return "/admin/addRepository";
+}
+
+/**
+ * http method this handler will serve
+ */
+function method() {
+  return "post";
+}
+
+/**
+ * handle addRepository
+ * @param {*} req
+ * @param {*} res
+ * @param {*} dependencies
+ */
+async function handle(req, res, dependencies, owners) {
+  const owner = req.body.owner;
+  const repository = req.body.repository;
+
+  await dependencies.db.storeRepository(owner, repository);
+  res.writeHead(301, {
+    Location: "/admin/repositories",
+  });
+  res.end();
+}
+
+module.exports.path = path;
+module.exports.method = method;
+module.exports.handle = handle;

--- a/controllers/admin/enterNewRepository.js
+++ b/controllers/admin/enterNewRepository.js
@@ -1,0 +1,21 @@
+/**
+ * path this handler will serve
+ */
+function path() {
+  return "/admin/enterNewRepository";
+}
+
+/**
+ * handle executeTaskSelection
+ * @param {*} req
+ * @param {*} res
+ * @param {*} dependencies
+ */
+async function handle(req, res, dependencies, owners) {
+  res.render(dependencies.viewsPath + "admin/enterNewRepository", {
+    owners: owners,
+  });
+}
+
+module.exports.path = path;
+module.exports.handle = handle;

--- a/views/admin/enterNewRepository.pug
+++ b/views/admin/enterNewRepository.pug
@@ -1,0 +1,20 @@
+extends ../layout
+include ../components/titleBar
+include ../components/tableHeader
+include ../components/tableCell
+include ../components/tableRow
+include ../components/formSelect
+include ../components/tableCellButton
+include ../components/formInput
+
+block content
+
+  +titleBar([{title: 'Enter New Repository'}])
+  div(class="flex flex-wrap m-4")
+    form(class="w-full m-4" method="POST" action="/admin/addRepository" encType="multipart/form-data")
+      div(class="w-1/4 md:flex mb-6")
+        +formInput("owner", "owner")
+      div(class="w-1/4 md:flex mb-6")
+        +formInput("repository", "repository")
+      div(class="w-1/5 px-3 mb-6 md:mb-0 md:items-right")
+        button(class="bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded") Add Repository

--- a/views/admin/repositories.pug
+++ b/views/admin/repositories.pug
@@ -19,3 +19,8 @@ block content
           +tableRow('/admin/repositoryAdmin?owner=' + repo.owner + '&repository=' + repo.repository)
             +tableCell(repo.owner)
             +tableCell(repo.repository)
+
+
+    div(class="p-4")
+      form(class="w-full m-4" method="GET" action="/admin/enterNewRepository" encType="multipart/form-data")
+        button(class="bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded") Add Repository


### PR DESCRIPTION
This PR adds the ability for admins to add repositories to the database.  This can be useful for cases where the repository hasn't had activity so it doesn't show up in the list yet. Then at least Admins can setup defaults & builds without requiring commits/etc to the repository.

closes #278 