### PR TITLE
♻️ Sidebar menu adjusts based on admin login

### DIFF
--- a/controllers/admin/defaults.js
+++ b/controllers/admin/defaults.js
@@ -31,6 +31,7 @@ async function handle(req, res, dependencies, owners) {
   }
   res.render(dependencies.viewsPath + "admin/defaults", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     defaults: configDefaults,
   });
 }

--- a/controllers/admin/enterNewRepository.js
+++ b/controllers/admin/enterNewRepository.js
@@ -14,6 +14,7 @@ function path() {
 async function handle(req, res, dependencies, owners) {
   res.render(dependencies.viewsPath + "admin/enterNewRepository", {
     owners: owners,
+    isAdmin: req.validAdminSession,
   });
 }
 

--- a/controllers/admin/executeTask.js
+++ b/controllers/admin/executeTask.js
@@ -82,6 +82,7 @@ async function handle(req, res, dependencies, owners) {
 
   res.render(dependencies.viewsPath + "admin/executeTask", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     owner: req.body.owner,
     repository: req.body.repository,
   });

--- a/controllers/admin/executeTaskConfig.js
+++ b/controllers/admin/executeTaskConfig.js
@@ -107,6 +107,7 @@ async function handle(req, res, dependencies, owners) {
 
   res.render(dependencies.viewsPath + "admin/executeTaskConfig", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     owner: owner,
     repository: repository,
     task: req.body.task,

--- a/controllers/admin/executeTaskSelection.js
+++ b/controllers/admin/executeTaskSelection.js
@@ -22,6 +22,7 @@ async function handle(req, res, dependencies, owners) {
 
   res.render(dependencies.viewsPath + "admin/executeTaskSelection", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     owner: owner,
     repository: repository,
     taskList: sortedTasks,

--- a/controllers/admin/info.js
+++ b/controllers/admin/info.js
@@ -23,6 +23,7 @@ function requiresAdmin() {
 async function handle(req, res, dependencies, owners) {
   res.render(dependencies.viewsPath + "admin/info", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     version: module.exports.version,
   });
 }

--- a/controllers/admin/login.js
+++ b/controllers/admin/login.js
@@ -23,6 +23,7 @@ function requiresAdmin() {
 async function handle(req, res, dependencies, owners) {
   res.render(dependencies.viewsPath + "admin/login", {
     owners: owners,
+    isAdmin: req.validAdminSession,
   });
 }
 

--- a/controllers/admin/overrides.js
+++ b/controllers/admin/overrides.js
@@ -31,6 +31,7 @@ async function handle(req, res, dependencies, owners) {
   }
   res.render(dependencies.viewsPath + "admin/overrides", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     overrides: configOverrides,
   });
 }

--- a/controllers/admin/owners.js
+++ b/controllers/admin/owners.js
@@ -21,6 +21,7 @@ function requiresAdmin() {
 async function handle(req, res, dependencies, owners) {
   res.render(dependencies.viewsPath + "admin/owners", {
     owners: owners,
+    isAdmin: req.validAdminSession,
   });
 }
 

--- a/controllers/admin/queues.js
+++ b/controllers/admin/queues.js
@@ -22,6 +22,7 @@ async function handle(req, res, dependencies, owners) {
   const queueList = await dependencies.cache.systemQueues.fetchSystemQueues();
   res.render(dependencies.viewsPath + "admin/queues", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     queues: queueList != null ? queueList : [],
   });
 }

--- a/controllers/admin/repositories.js
+++ b/controllers/admin/repositories.js
@@ -22,6 +22,7 @@ async function handle(req, res, dependencies, owners) {
   const repositories = await dependencies.db.fetchRepositories();
   res.render(dependencies.viewsPath + "admin/repositories", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     owner: req.query.owner,
     repositories: repositories.rows,
   });

--- a/controllers/admin/repositoryAdmin.js
+++ b/controllers/admin/repositoryAdmin.js
@@ -72,6 +72,7 @@ async function handle(req, res, dependencies, owners) {
 
   res.render(dependencies.viewsPath + "admin/repositoryAdmin", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     owner: owner,
     repository: repository,
     nextBuildNumber: parseInt(buildNumber) + 1,

--- a/controllers/admin/repositoryBuildDetails.js
+++ b/controllers/admin/repositoryBuildDetails.js
@@ -26,6 +26,7 @@ async function handle(req, res, dependencies, owners) {
 
   res.render(dependencies.viewsPath + "admin/repositoryBuildDetails", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     owner: owner,
     repository: repository,
     buildID: buildID,

--- a/controllers/admin/selectConfigSource.js
+++ b/controllers/admin/selectConfigSource.js
@@ -24,6 +24,7 @@ async function handle(req, res, dependencies, owners) {
 
   res.render(dependencies.viewsPath + "admin/selectConfigSource", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     owner: owner,
     repository: repository,
   });

--- a/controllers/admin/selectNewOwner.js
+++ b/controllers/admin/selectNewOwner.js
@@ -28,6 +28,7 @@ async function handle(req, res, dependencies, owners) {
   }
   res.render(dependencies.viewsPath + "admin/selectNewOwner", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     newOwners: newOwners,
   });
 }

--- a/controllers/admin/taskConfig.js
+++ b/controllers/admin/taskConfig.js
@@ -40,6 +40,7 @@ async function handle(req, res, dependencies, owners) {
 
   res.render(dependencies.viewsPath + "admin/taskConfig", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     taskID: req.query.taskID,
     taskDetails: taskDetails,
     config: taskDetails.config != null ? taskDetails.config : [],

--- a/controllers/admin/tasks.js
+++ b/controllers/admin/tasks.js
@@ -33,6 +33,7 @@ async function handle(req, res, dependencies, owners) {
   }
   res.render(dependencies.viewsPath + "admin/tasks", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     tasks: tasks,
   });
 }

--- a/controllers/admin/uploadDefaults.js
+++ b/controllers/admin/uploadDefaults.js
@@ -48,6 +48,7 @@ async function handle(req, res, dependencies, owners) {
   }
   res.render(dependencies.viewsPath + "admin/defaults", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     defaults: configDefaults,
   });
 }

--- a/controllers/admin/uploadOverrides.js
+++ b/controllers/admin/uploadOverrides.js
@@ -48,6 +48,7 @@ async function handle(req, res, dependencies, owners) {
   }
   res.render(dependencies.viewsPath + "admin/overrides", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     overrides: configOverrides,
   });
 }

--- a/controllers/admin/uploadQueues.js
+++ b/controllers/admin/uploadQueues.js
@@ -39,6 +39,7 @@ async function handle(req, res, dependencies, owners) {
   const queueList = await dependencies.cache.systemQueues.fetchSystemQueues();
   res.render(dependencies.viewsPath + "admin/queues", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     queues: queueList != null ? queueList : [],
   });
 }

--- a/controllers/admin/viewCachedConfig.js
+++ b/controllers/admin/viewCachedConfig.js
@@ -31,6 +31,7 @@ async function handle(req, res, dependencies, owners) {
 
   res.render(dependencies.viewsPath + "admin/viewCachedConfig", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     owner: owner,
     repository: repository,
     repoConfig: repoConfig != null ? yaml.safeDump(repoConfig) : null,

--- a/controllers/admin/viewOrgConfigDefaults.js
+++ b/controllers/admin/viewOrgConfigDefaults.js
@@ -37,6 +37,7 @@ async function handle(req, res, dependencies, owners) {
   }
   res.render(dependencies.viewsPath + "admin/viewOrgConfigDefaults", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     owner: owner,
     repository: repository,
     defaults: configDefaults,

--- a/controllers/admin/viewOrgConfigOverrides.js
+++ b/controllers/admin/viewOrgConfigOverrides.js
@@ -37,6 +37,7 @@ async function handle(req, res, dependencies, owners) {
   }
   res.render(dependencies.viewsPath + "admin/viewOrgConfigOverrides", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     owner: owner,
     repository: repository,
     overrides: configOverrides,

--- a/controllers/admin/viewRepoConfigDefaults.js
+++ b/controllers/admin/viewRepoConfigDefaults.js
@@ -38,6 +38,7 @@ async function handle(req, res, dependencies, owners) {
   }
   res.render(dependencies.viewsPath + "admin/viewRepoConfigDefaults", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     owner: owner,
     repository: repository,
     defaults: configDefaults,

--- a/controllers/admin/viewRepoConfigOverrides.js
+++ b/controllers/admin/viewRepoConfigOverrides.js
@@ -38,6 +38,7 @@ async function handle(req, res, dependencies, owners) {
   }
   res.render(dependencies.viewsPath + "admin/viewRepoConfigOverrides", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     owner: owner,
     repository: repository,
     overrides: configOverrides,

--- a/controllers/history/buildDetails.js
+++ b/controllers/history/buildDetails.js
@@ -50,6 +50,7 @@ async function handle(req, res, dependencies, owners) {
   }
   res.render(dependencies.viewsPath + "history/buildDetails", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     build: buildDetails,
     duration: duration,
     tasks: tasks,

--- a/controllers/history/buildSummary.js
+++ b/controllers/history/buildSummary.js
@@ -55,6 +55,7 @@ async function handle(req, res, dependencies, owners) {
   };
   res.render(dependencies.viewsPath + "history/buildSummary", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     data: data,
     summary: summary,
   });

--- a/controllers/history/buildTaskDetails.js
+++ b/controllers/history/buildTaskDetails.js
@@ -40,6 +40,7 @@ async function handle(req, res, dependencies, owners) {
         : [];
     res.render(dependencies.viewsPath + "history/buildTaskDetails", {
       owners: owners,
+      isAdmin: req.validAdminSession,
       task: task,
       build: build,
       taskDetails: taskDetails,
@@ -49,6 +50,7 @@ async function handle(req, res, dependencies, owners) {
   } else {
     res.render(dependencies.viewsPath + "history/buildTaskDetails", {
       owners: owners,
+      isAdmin: req.validAdminSession,
       task: {},
       build: {},
       taskDetails: { details: {} },

--- a/controllers/history/builds.js
+++ b/controllers/history/builds.js
@@ -53,6 +53,7 @@ async function handle(req, res, dependencies, owners) {
 
   res.render(dependencies.viewsPath + "history/builds", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     builds: builds.rows,
     timeFilter: timeFilter,
     timeFilterList: ["Last 8 hours", "Today", "Yesterday"],

--- a/controllers/history/dailySummary.js
+++ b/controllers/history/dailySummary.js
@@ -76,6 +76,7 @@ async function handle(req, res, dependencies, owners) {
 
   res.render(dependencies.viewsPath + "history/dailySummary", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     yesterdayBuilds: yesterdayBuildsCount,
     yesterdayTasks: yesterdayTasksCount,
     todayBuilds: todayBuildsCount,

--- a/controllers/history/requeueTask.js
+++ b/controllers/history/requeueTask.js
@@ -40,6 +40,7 @@ async function handle(req, res, dependencies, owners) {
 
     res.render(dependencies.viewsPath + "history/requeueTask", {
       owners: owners,
+      isAdmin: req.validAdminSession,
       task: task,
       taskDetails: taskDetails,
       build: build,
@@ -47,6 +48,7 @@ async function handle(req, res, dependencies, owners) {
   } else {
     res.render(dependencies.viewsPath + "history/requeueTask", {
       owners: owners,
+      isAdmin: req.validAdminSession,
       task: {},
       taskDetails: { details: {} },
       build: {},

--- a/controllers/history/taskDetails.js
+++ b/controllers/history/taskDetails.js
@@ -48,6 +48,7 @@ async function handle(req, res, dependencies, owners) {
 
   res.render(dependencies.viewsPath + "history/taskDetails", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     task: task,
     build: build,
     taskDetails: taskDetails,

--- a/controllers/history/taskSummary.js
+++ b/controllers/history/taskSummary.js
@@ -113,6 +113,7 @@ async function handle(req, res, dependencies, owners) {
 
   res.render(dependencies.viewsPath + "history/taskSummary", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     graphs: graphs,
     timeFilter: timeFilter,
     timeFilterList: ["Last 8 hours", "Today", "Yesterday"],

--- a/controllers/history/tasks.js
+++ b/controllers/history/tasks.js
@@ -84,6 +84,7 @@ async function handle(req, res, dependencies, owners) {
 
   res.render(dependencies.viewsPath + "history/tasks", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     tasks: tasks.rows,
     timeFilter: timeFilter,
     timeFilterList: ["Last 8 hours", "Today", "Yesterday"],

--- a/controllers/index.js
+++ b/controllers/index.js
@@ -21,6 +21,7 @@ function requiresAdmin() {
 async function handle(req, res, dependencies, owners) {
   res.render(dependencies.viewsPath + "index", {
     owners: owners,
+    isAdmin: req.validAdminSession,
   });
 }
 

--- a/controllers/monitor/activeBuilds.js
+++ b/controllers/monitor/activeBuilds.js
@@ -17,6 +17,7 @@ async function handle(req, res, dependencies, owners) {
   const builds = await dependencies.db.activeBuilds();
   res.render(dependencies.viewsPath + "monitor/activeBuilds", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     builds: builds.rows,
     prettyMilliseconds: (ms) => (ms != null ? prettyMilliseconds(ms) : ""),
   });

--- a/controllers/monitor/activeTasks.js
+++ b/controllers/monitor/activeTasks.js
@@ -40,6 +40,7 @@ async function handle(req, res, dependencies, owners) {
 
   res.render(dependencies.viewsPath + "monitor/activeTasks", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     tasks: sortedTasks,
     prettyMilliseconds: (ms) => (ms != null ? prettyMilliseconds(ms) : ""),
   });

--- a/controllers/monitor/buildDetails.js
+++ b/controllers/monitor/buildDetails.js
@@ -50,6 +50,7 @@ async function handle(req, res, dependencies, owners) {
   }
   res.render(dependencies.viewsPath + "monitor/buildDetails", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     build: buildDetails,
     duration: duration,
     tasks: tasks,

--- a/controllers/monitor/buildTaskDetails.js
+++ b/controllers/monitor/buildTaskDetails.js
@@ -51,6 +51,7 @@ async function handle(req, res, dependencies, owners) {
 
     res.render(dependencies.viewsPath + "monitor/buildTaskDetails", {
       owners: owners,
+      isAdmin: req.validAdminSession,
       task: task,
       build: build,
       taskDetails: taskDetails,
@@ -62,6 +63,7 @@ async function handle(req, res, dependencies, owners) {
   } else {
     res.render(dependencies.viewsPath + "monitor/buildTaskDetails", {
       owners: owners,
+      isAdmin: req.validAdminSession,
       task: {},
       build: {},
       taskDetails: { details: {} },

--- a/controllers/monitor/cancelTask.js
+++ b/controllers/monitor/cancelTask.js
@@ -38,6 +38,7 @@ async function handle(req, res, dependencies, owners) {
     taskQueue.close();
     res.render(dependencies.viewsPath + "monitor/cancelTask", {
       owners: owners,
+      isAdmin: req.validAdminSession,
       task: task,
       taskDetails: taskDetails,
       build: build,
@@ -45,6 +46,7 @@ async function handle(req, res, dependencies, owners) {
   } else {
     res.render(dependencies.viewsPath + "monitor/cancelTask", {
       owners: owners,
+      isAdmin: req.validAdminSession,
       task: {},
       taskDetails: { details: {} },
       build: {},

--- a/controllers/monitor/queues.js
+++ b/controllers/monitor/queues.js
@@ -30,6 +30,7 @@ async function handle(req, res, dependencies, owners) {
   }
   res.render(dependencies.viewsPath + "monitor/queues", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     queues: queues,
   });
 }

--- a/controllers/monitor/requeueTask.js
+++ b/controllers/monitor/requeueTask.js
@@ -40,6 +40,7 @@ async function handle(req, res, dependencies, owners) {
 
     res.render(dependencies.viewsPath + "monitor/requeueTask", {
       owners: owners,
+      isAdmin: req.validAdminSession,
       task: task,
       taskDetails: taskDetails,
       build: build,
@@ -47,6 +48,7 @@ async function handle(req, res, dependencies, owners) {
   } else {
     res.render(dependencies.viewsPath + "monitor/requeueTask", {
       owners: owners,
+      isAdmin: req.validAdminSession,
       task: {},
       taskDetails: { details: {} },
       build: {},

--- a/controllers/monitor/workerDetails.js
+++ b/controllers/monitor/workerDetails.js
@@ -21,6 +21,7 @@ async function handle(req, res, dependencies, owners) {
   }
   res.render(dependencies.viewsPath + "monitor/workerDetails", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     worker: worker != null ? worker : { lastTask: {} },
   });
 }

--- a/controllers/monitor/workers.js
+++ b/controllers/monitor/workers.js
@@ -31,6 +31,7 @@ async function handle(req, res, dependencies, owners) {
   });
   res.render(dependencies.viewsPath + "monitor/workers", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     workers: sortedWorkers,
     prettyMilliseconds: (ms) => (ms != null ? prettyMilliseconds(ms) : ""),
   });

--- a/controllers/repositories/buildDetails.js
+++ b/controllers/repositories/buildDetails.js
@@ -51,6 +51,7 @@ async function handle(req, res, dependencies, owners) {
   }
   res.render(dependencies.viewsPath + "repositories/buildDetails", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     build: buildDetails,
     duration: duration,
     tasks: tasks,

--- a/controllers/repositories/executeRepositoryBuild.js
+++ b/controllers/repositories/executeRepositoryBuild.js
@@ -47,6 +47,7 @@ async function handle(req, res, dependencies, owners) {
 
     res.render(dependencies.viewsPath + "repositories/executeRepositoryBuild", {
       owners: owners,
+      isAdmin: req.validAdminSession,
       owner: owner,
       repository: repository,
     });

--- a/controllers/repositories/executeRepositoryBuildWithBranch.js
+++ b/controllers/repositories/executeRepositoryBuildWithBranch.js
@@ -40,6 +40,7 @@ async function handle(req, res, dependencies, owners) {
 
   res.render(dependencies.viewsPath + "repositories/executeRepositoryBuild", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     owner: owner,
     repository: repository,
   });

--- a/controllers/repositories/repositories.js
+++ b/controllers/repositories/repositories.js
@@ -17,6 +17,7 @@ async function handle(req, res, dependencies, owners) {
   );
   res.render(dependencies.viewsPath + "repositories/repositories", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     owner: req.query.owner,
     repositories: repositories.rows,
   });

--- a/controllers/repositories/repositoryDetails.js
+++ b/controllers/repositories/repositoryDetails.js
@@ -84,6 +84,7 @@ async function handle(req, res, dependencies, owners) {
 
   res.render(dependencies.viewsPath + "repositories/repositoryDetails", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     owner: owner,
     repository: repository,
     recentBuilds: recentBuilds.rows,

--- a/controllers/repositories/requeueTask.js
+++ b/controllers/repositories/requeueTask.js
@@ -37,6 +37,7 @@ async function handle(req, res, dependencies, owners) {
 
   res.render(dependencies.viewsPath + "repositories/requeueTask", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     task: task,
     taskDetails: taskDetails,
     build: build,

--- a/controllers/repositories/selectRepositoryBuildBranch.js
+++ b/controllers/repositories/selectRepositoryBuildBranch.js
@@ -20,6 +20,7 @@ async function handle(req, res, dependencies, owners) {
     dependencies.viewsPath + "repositories/selectRepositoryBuildBranch",
     {
       owners: owners,
+      isAdmin: req.validAdminSession,
       owner: owner,
       repository: repository,
       build: buildID,

--- a/controllers/repositories/taskDetails.js
+++ b/controllers/repositories/taskDetails.js
@@ -48,6 +48,7 @@ async function handle(req, res, dependencies, owners) {
 
   res.render(dependencies.viewsPath + "repositories/taskDetails", {
     owners: owners,
+    isAdmin: req.validAdminSession,
     task: task,
     build: build,
     taskDetails: taskDetails,

--- a/views/components/sideBar.pug
+++ b/views/components/sideBar.pug
@@ -2,7 +2,7 @@ include sideBarSection
 include sideBarHeader
 include sideBarItem
 
-mixin sideBar(activeMenu, owners)
+mixin sideBar(activeMenu, owners, isAdmin)
     div(class="bg-gray-800 shadow-lg h-16 fixed bottom-0 md:relative md:h-screen z-10 w-full md:w-48")
         div(class="md:mt-12 md:w-48 md:fixed md:left-0 md:top-0 content-center md:content-start text-left justify-between")
             ul(class="list-reset flex flex-row md:flex-col py-0 md:py-3 px-1 md:px-2 text-center md:text-left mt-6")
@@ -27,13 +27,18 @@ mixin sideBar(activeMenu, owners)
                     {title: 'Task Summary', href: '/history/taskSummary'},
                     {title: 'Daily Summary', href: '/history/dailySummary', class: 'pb-3'}
                     ])
-                +sideBarSection('Admin', 'user-cog', [
-                    {title: 'Tasks', href: '/admin/tasks'},
-                    {title: 'Owners', href: '/admin/owners'},
-                    {title: 'Repositories', href: '/admin/repositories'},
-                    {title: 'Defaults', href: '/admin/defaults'},
-                    {title: 'Overrides', href: '/admin/overrides'},
-                    {title: 'Queues', href: '/admin/queues'},
-                    {title: 'Info', href: '/admin/info'},
-                    {title: 'Logout', href: '/admin/logout'}
+                if isAdmin == true
+                    +sideBarSection('Admin', 'user-cog', [
+                        {title: 'Tasks', href: '/admin/tasks'},
+                        {title: 'Owners', href: '/admin/owners'},
+                        {title: 'Repositories', href: '/admin/repositories'},
+                        {title: 'Defaults', href: '/admin/defaults'},
+                        {title: 'Overrides', href: '/admin/overrides'},
+                        {title: 'Queues', href: '/admin/queues'},
+                        {title: 'Info', href: '/admin/info'},
+                        {title: 'Logout', href: '/admin/logout'}
+                        ])
+                else
+                    +sideBarSection('Admin', 'user-cog', [
+                        {title: 'Login', href: '/admin/login'},
                     ])

--- a/views/history/layout.pug
+++ b/views/history/layout.pug
@@ -20,7 +20,7 @@ html
     div(class="flex flex-col md:flex-row")
 
       //- Sidebar
-      +sideBar('History', owners)
+      +sideBar('History', owners, isAdmin)
 
       //- Content area
       div(class="main-content flex-1 bg-gray-100 mt-12 md:mt-2 pb-24 md:pb-5")

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -20,7 +20,7 @@ html
     div(class="flex flex-col md:flex-row")
 
       //- Sidebar
-      +sideBar('History', owners)
+      +sideBar('History', owners, isAdmin)
 
       //- Content area
       div(class="main-content flex-1 bg-gray-100 mt-12 md:mt-2 pb-24 md:pb-5")


### PR DESCRIPTION
This PR updates the sidebar menu based on user logged in as admin or not. Now when not logged in as admin, the admin section will only show a login item. Once logged in, the full menu will display along with a logout.

closes #265 