### PR TITLE
✨ Added a cancel build button to active build details

### DIFF
--- a/controllers/monitor/cancelBuild.js
+++ b/controllers/monitor/cancelBuild.js
@@ -1,0 +1,49 @@
+/**
+ * path this handler will serve
+ */
+function path() {
+  return "/monitor/cancelBuild";
+}
+
+/**
+ * handle
+ * @param {*} req
+ * @param {*} res
+ * @param {*} dependencies
+ */
+async function handle(req, res, dependencies, owners) {
+  const buildID = req.query.buildID;
+  await dependencies.cache.removeBuildFromActiveList(buildID);
+  const remainingTasks = await dependencies.cache.fetchActiveTasks(buildID);
+  for (let index = 0; index < remainingTasks.length; index++) {
+    await dependencies.cache.removeTaskFromActiveList(
+      buildID,
+      remainingTasks[index]
+    );
+    try {
+      await dependencies.db.storeTaskCompleted(
+        remainingTasks[index],
+        "cancelled",
+        new Date(),
+        new Date(),
+        "cancelled"
+      );
+    } catch (e) {
+      logger.error("Error storing task completed details: " + e);
+    }
+  }
+
+  try {
+    await dependencies.db.storeBuildComplete(buildID, "cancelled");
+  } catch (e) {
+    logger.error("Error storing build completed details: " + e);
+  }
+
+  res.render(dependencies.viewsPath + "monitor/cancelBuild", {
+    owners: owners,
+    isAdmin: req.validAdminSession,
+  });
+}
+
+module.exports.path = path;
+module.exports.handle = handle;

--- a/views/monitor/buildDetails.pug
+++ b/views/monitor/buildDetails.pug
@@ -36,6 +36,9 @@ block content
               +tableRow()
                 +tableCell('Started At')
                 +tableCell(build.started_at)
+              +tableRow()
+                +tableCellButton('Cancel', '/monitor/cancelBuild?buildID=' + build.build_id)
+                +tableCell('')
 
   div(class="w-full p-3")
       div(class="bg-white border-transparent rounded-lg shadow-lg")

--- a/views/monitor/cancelBuild.pug
+++ b/views/monitor/cancelBuild.pug
@@ -1,0 +1,12 @@
+extends ../layout
+include ../components/titleBar
+include ../components/tableHeader
+include ../components/tableCell
+include ../components/tableRow
+
+block content
+
+  +titleBar([{title: 'Active Builds', href: '/monitor/activeBuilds'}])
+  div(class="flex flex-wrap m-4")
+
+  h5 Build Cancelled


### PR DESCRIPTION
This PR adds a cancel build button to the active build details screen. Note that this doesn't technically cancel the tasks, they will still run and perhaps complete the build. The cancel build just removes it from the active builds list.

closes #234 
