### PR TITLE
🐛 Mark a task as a failure if the check run details can't be applied

### DIFF
--- a/scm/github.js
+++ b/scm/github.js
@@ -299,6 +299,7 @@ async function updateCheck(owner, repo, serverConf, update) {
     if (update.output.text != null) {
       systemLogger.error("Text size is: " + update.output.text.length);
     }
+    update.conclusion = "failure";
     update.output = {
       title: "Task Results",
       summary: "Error applying task results, contact your stampede admin.",


### PR DESCRIPTION
This PR changes the behavior of a failed check run update. Now it will mark the check run as a failure. This is a stampede failure, but we shouldn't give the user the false impression that the task was fully successful. These failures will eventually be tagged as a system failure, but until then we want to see these as failures so the underlying problem can be addressed (and known that it happened).

closes #243 