### PR TITLE
♻️ Changed time filter for recent builds

### DIFF
--- a/controllers/repositories/repositoryDetails.js
+++ b/controllers/repositories/repositoryDetails.js
@@ -16,7 +16,7 @@ async function handle(req, res, dependencies, owners) {
   const repository = req.query.repository;
 
   const recentBuilds = await dependencies.db.recentBuilds(
-    "Last 8 hours",
+    "Last 3 Days",
     "All",
     owner + "/" + repository
   );

--- a/controllers/repositories/repositoryDetails.js
+++ b/controllers/repositories/repositoryDetails.js
@@ -16,7 +16,7 @@ async function handle(req, res, dependencies, owners) {
   const repository = req.query.repository;
 
   const recentBuilds = await dependencies.db.recentBuilds(
-    "Last 3 Days",
+    "Last 7 Days",
     "All",
     owner + "/" + repository
   );


### PR DESCRIPTION
This PR changes the time filter for Recent Builds on the Repository details screen to the last 7 days instead of just last 8 hours. Will still want a way to go directly to history to see even further back.

closes #361