### PR TITLE
🐛 fixed error when commit message not in github event

### DIFF
--- a/events/push.js
+++ b/events/push.js
@@ -113,7 +113,10 @@ function parseEvent(req) {
     sha: req.body.after,
     cloneURL: req.body.repository.clone_url,
     sshURL: req.body.repository.ssh_url,
-    commitMessage: req.body.head_commit.message,
+    commitMessage:
+      req.body.head_commit != null && req.body.head_commit.message != null
+        ? req.body.head_commit.message
+        : "",
   };
 }
 


### PR DESCRIPTION
This PR fixes an error that was caused by a GitHub event that didn't have a commit message.

closes #367 