### PR TITLE
✨ Stop ignoring push events that create branches

### DIFF
--- a/events/push.js
+++ b/events/push.js
@@ -20,9 +20,9 @@ async function handle(req, serverConf, cache, scm, db, logger) {
 
   await db.storeRepository(event.owner, event.repo);
 
-  if (event.created === true || event.deleted === true) {
-    logger.verbose("Ignoring push since it is created or deleted");
-    return { status: "ignoring due to created or pushed" };
+  if (event.deleted === true) {
+    logger.verbose("Ignoring push since it is for a deleted branch");
+    return { status: "ignoring due to deleted branch" };
   }
 
   const repoConfig = await config.findRepoConfig(


### PR DESCRIPTION
This PR changes the behavior of the push event and no longer ignores branch creation events. Originally this was due to pull requests, but even for PR branches it is ok for the system to check the .stampede.yaml file to see if anything should be done for the branch. Now it would be possible to run some tasks just at the branch level in addition to the pull requests. Mostly this fixes an issue where someone creates a new branch and adds/changes their .stampede.yaml to match the branch and then pushes. They expect tasks to run in this case.

closes #369