### PR TITLE
♻️ Make requeue button depend on admin access

### DIFF
--- a/views/history/buildTaskDetails.pug
+++ b/views/history/buildTaskDetails.pug
@@ -33,9 +33,10 @@ block content
                 +tableRow()
                   +tableCell(detail.title)
                   +tableCell(detail.value)
-              +tableRow()
-                +tableCellButton('Requeue', '/history/requeueTask?taskID=' + task.task_id)
-                +tableCell('')
+              if isAdmin == true
+                +tableRow()
+                  +tableCellButton('Requeue', '/history/requeueTask?taskID=' + task.task_id)
+                  +tableCell('')
 
     if configValues.length > 0
       +infoCard('Task Config')

--- a/views/history/taskDetails.pug
+++ b/views/history/taskDetails.pug
@@ -34,9 +34,10 @@ block content
                 +tableRow()
                   +tableCell(detail.title)
                   +tableCell(detail.value)
-              +tableRow()
-                +tableCellButton('Requeue', '/history/requeueTask?taskID=' + task.task_id)
-                +tableCell('')
+              if isAdmin == true
+                +tableRow()
+                  +tableCellButton('Requeue', '/history/requeueTask?taskID=' + task.task_id)
+                  +tableCell('')
 
     +infoCard('Build Information')
         table(class="table-auto w-full")

--- a/views/repositories/taskDetails.pug
+++ b/views/repositories/taskDetails.pug
@@ -31,9 +31,10 @@ block content
                 +tableRow()
                   +tableCell(detail.title)
                   +tableCell(detail.value)
-              +tableRow()
-                +tableCellButton('Requeue', '/repositories/requeueTask?taskID=' + task.task_id)
-                +tableCell('')
+              if isAdmin == true
+                +tableRow()
+                  +tableCellButton('Requeue', '/repositories/requeueTask?taskID=' + task.task_id)
+                  +tableCell('')
 
     if configValues.length > 0
       +infoCard('Task Config')


### PR DESCRIPTION
This PR makes the re-queue button on task details depend on admin access. Usually this operation is when the admin is working on an issue with a node or task script. And it might be confusing for average users.

closes #379 
