### PR TITLE
🐛 Fixed sidebar sometimes going to 0 width

### DIFF
--- a/views/components/sideBar.pug
+++ b/views/components/sideBar.pug
@@ -3,8 +3,8 @@ include sideBarHeader
 include sideBarItem
 
 mixin sideBar(activeMenu, owners, isAdmin)
-    div(class="shadow-lg h-16 fixed bottom-0 md:relative md:h-screen z-10 w-full md:w-48")
-        div(class="md:mt-12 md:w-48 md:fixed md:left-0 md:top-0 content-center md:content-start text-left justify-between")
+    div(class="shadow-lg h-16 fixed bottom-0 md:relative md:h-screen z-10 flex-shrink-0 w-48")
+        div(class="md:mt-12 md:fixed md:left-0 md:top-0 content-center md:content-start text-left justify-between")
             ul(class="list-reset flex flex-row md:flex-col py-0 md:py-3 px-1 md:px-2 text-center md:text-left mt-6")
 
                 +sideBarHeader('Repositories', 'address-book')

--- a/views/repositories/taskDetails.pug
+++ b/views/repositories/taskDetails.pug
@@ -85,7 +85,7 @@ block content
               marked(document.getElementById('task-result-summary-data').innerHTML, {gfm: true});
 
         +infoCard('Text')
-          div(id="task-result-text")
+          div(id="task-result-text" class="overflow-scroll")
           data(id="task-result-text-data" hidden)
             = text
           script.


### PR DESCRIPTION
This PR fixes an issue where sometimes the sidebar background would disappear and the menu items would float over the top of the task details. This happened mostly when there was a task with a specific type of response. I think its due to the width, but not completely sure the trigger.

closes #362 