### PR TITLE
🐛 Fixed bug on task health repo filtering

### DIFF
--- a/controllers/history/taskHealth.js
+++ b/controllers/history/taskHealth.js
@@ -40,7 +40,6 @@ async function handle(req, res, dependencies, owners) {
 
   const tasksRows = await dependencies.db.taskHealth(
     timeFilter,
-    taskFilter,
     repositoryFilter
   );
 


### PR DESCRIPTION
This PR fixes a bug in the task health screen where the repository filter didn't work.

closes #383 
