### PR TITLE
🐛 fixed number of hours returned in hourly summary

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -424,7 +424,7 @@ async function summarizeRecentBuilds() {
 
 async function summarizeHourlyBuilds() {
   let query =
-    "with hours as (select generate_series(date_trunc('hour', now()) - '1 day'::interval, \
+    "with hours as (select generate_series(date_trunc('hour', now()) - '23 hour'::interval, \
   date_trunc('hour', now()), '1 hour'::interval) as hour ) select hours.hour, count(builds.build_id) \
   from hours \
   left join stampede.builds on date_trunc('hour', started_at) = hours.hour group by 1 order by hour";
@@ -433,7 +433,7 @@ async function summarizeHourlyBuilds() {
 
 async function summarizeHourlyTasks() {
   let query =
-    "with hours as (select generate_series(date_trunc('hour', now()) - '1 day'::interval, \
+    "with hours as (select generate_series(date_trunc('hour', now()) - '23 hour'::interval, \
   date_trunc('hour', now()), '1 hour'::interval) as hour ) select hours.hour, count(tasks.task_id) \
   from hours \
   left join stampede.tasks on date_trunc('hour', started_at) = hours.hour group by 1 order by hour";


### PR DESCRIPTION
This PR fixes the number of hours in hourly summary from 25 back to 24.

closes #396 