### PR TITLE
♻️ Moved some screens under admin

### DIFF
--- a/controllers/admin/reports.js
+++ b/controllers/admin/reports.js
@@ -1,0 +1,33 @@
+require("pkginfo")(module);
+
+/**
+ * path this handler will serve
+ */
+function path() {
+  return "/admin/reports";
+}
+
+/**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
+ * handle tasks
+ * @param {*} req
+ * @param {*} res
+ * @param {*} dependencies
+ */
+async function handle(req, res, dependencies, owners) {
+  res.render(dependencies.viewsPath + "admin/reports", {
+    owners: owners,
+    isAdmin: req.validAdminSession,
+    version: module.exports.version,
+  });
+}
+
+module.exports.path = path;
+module.exports.handle = handle;
+module.exports.requiresAdmin = requiresAdmin;

--- a/controllers/admin/systemConfig.js
+++ b/controllers/admin/systemConfig.js
@@ -1,0 +1,33 @@
+require("pkginfo")(module);
+
+/**
+ * path this handler will serve
+ */
+function path() {
+  return "/admin/systemConfig";
+}
+
+/**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
+ * handle tasks
+ * @param {*} req
+ * @param {*} res
+ * @param {*} dependencies
+ */
+async function handle(req, res, dependencies, owners) {
+  res.render(dependencies.viewsPath + "admin/systemConfig", {
+    owners: owners,
+    isAdmin: req.validAdminSession,
+    version: module.exports.version,
+  });
+}
+
+module.exports.path = path;
+module.exports.handle = handle;
+module.exports.requiresAdmin = requiresAdmin;

--- a/views/admin/reports.pug
+++ b/views/admin/reports.pug
@@ -1,0 +1,35 @@
+extends ../layout
+
+include ../components/titleBar
+include ../components/tableHeader
+include ../components/tableCell
+include ../components/tableRow
+
+block content
+
+  +titleBar([{title: 'Reports'}])
+  div(class="flex flex-wrap m-4")
+
+    table(class="table-auto w-full")
+        tbody
+            +tableRow('/history/buildSummary')
+                +tableCell('Build Summary')
+                +tableCell('View a summary of the builds that have completed')
+            +tableRow('/history/taskSummary')
+                +tableCell('Task Summary')
+                +tableCell('View a summary of the tasks that have completed')
+            +tableRow('/history/taskHealth')
+                +tableCell('Task Health')
+                +tableCell('View the health of completed tasks')
+            +tableRow('/history/hourlySummary')
+                +tableCell('Hourly Summary')
+                +tableCell('View an hourly summary of the past 24 hours')
+            +tableRow('/history/dailySummary')
+                +tableCell('Daily Summary')
+                +tableCell('View a daily summary of the past 30 days')
+            +tableRow('/history/buildTimeByOrg')
+                +tableCell('Build Time by Org')
+                +tableCell('View a chart of build time grouped by org')
+            +tableRow('/history/buildTimeByNode')
+                +tableCell('Build Time by Node')
+                +tableCell('View a chart of build time grouped by node')

--- a/views/admin/systemConfig.pug
+++ b/views/admin/systemConfig.pug
@@ -1,0 +1,32 @@
+extends ../layout
+
+include ../components/titleBar
+include ../components/tableHeader
+include ../components/tableCell
+include ../components/tableRow
+
+block content
+
+  +titleBar([{title: 'System Config'}])
+  div(class="flex flex-wrap m-4")
+
+    table(class="table-auto w-full")
+        tbody
+          +tableRow('/admin/tasks')
+            +tableCell('Tasks')
+            +tableCell('Manage the available tasks in the system')
+          +tableRow('/admin/owners')
+            +tableCell('Owners')
+            +tableCell('Manage the list of owners/orgs visible in the sidebar menu')
+          +tableRow('/admin/repositories')
+            +tableCell('Repositories')
+            +tableCell('Manage cached config, defaults and manual builds for individual repositories')
+          +tableRow('/admin/defaults')
+            +tableCell('System Defaults')
+            +tableCell('Manage the system wide defaults')
+          +tableRow('/admin/overrides')
+            +tableCell('System Overrides')
+            +tableCell('Manage the system wide overrides')
+          +tableRow('/admin/queues')
+            +tableCell('Queues')
+            +tableCell('Manage the system queues')

--- a/views/components/sideBar.pug
+++ b/views/components/sideBar.pug
@@ -17,28 +17,19 @@ mixin sideBar(activeMenu, owners, isAdmin)
                 +sideBarSection('Monitor', 'desktop', [
                     {title: 'Active Builds', href: '/monitor/activeBuilds'},
                     {title: 'Active Tasks', href: '/monitor/activeTasks'},
-                    {title: 'Workers', href: '/monitor/workers'},
                     {title: 'Queues', href: '/monitor/queues', class: 'pb-3'}
                     ])
+
                 +sideBarSection('History', 'history', [
                     {title: 'Builds', href: '/history/builds'},
-                    {title: 'Build Summary', href: '/history/buildSummary'},
-                    {title: 'Tasks', href: '/history/tasks'},
-                    {title: 'Task Health', href: '/history/taskHealth'},
-                    {title: 'Task Summary', href: '/history/taskSummary'},
-                    {title: 'Hourly Summary', href: '/history/hourlySummary'},
-                    {title: 'Daily Summary', href: '/history/dailySummary'},
-                    {title: 'Build Time by Org', href: '/history/buildTimeByOrg'},
-                    {title: 'Build Time by Node', href: '/history/buildTimeByNode', class: 'pb-3'}
+                    {title: 'Tasks', href: '/history/tasks', class: 'pb-3'},
                     ])
+
                 if isAdmin == true
                     +sideBarSection('Admin', 'user-cog', [
-                        {title: 'Tasks', href: '/admin/tasks'},
-                        {title: 'Owners', href: '/admin/owners'},
-                        {title: 'Repositories', href: '/admin/repositories'},
-                        {title: 'Defaults', href: '/admin/defaults'},
-                        {title: 'Overrides', href: '/admin/overrides'},
-                        {title: 'Queues', href: '/admin/queues'},
+                        {title: 'Workers', href: '/monitor/workers'},
+                        {title: 'System Config', href: '/admin/systemConfig'},
+                        {title: 'Reports', href: '/admin/reports'},
                         {title: 'Info', href: '/admin/info'},
                         {title: 'Logout', href: '/admin/logout'}
                         ])


### PR DESCRIPTION
This PR refactors the sidebar menu, moving some items under admin and creating 2 new groupings under admin: system config and reports. This will save on vertical space in the sidebar menu, allowing for more system config and reports to be created without worry of making the sidebar too big.

Also one side-effect is that non-admin users will no longer have access to a few screens which should have been admin only anyway. None of the screens that normal users need are hidden, they are still available.

closes #377 