### PR TITLE
🐛 prevent empty owner or repo to be added

### DIFF
--- a/controllers/admin/addRepository.js
+++ b/controllers/admin/addRepository.js
@@ -22,7 +22,14 @@ async function handle(req, res, dependencies, owners) {
   const owner = req.body.owner;
   const repository = req.body.repository;
 
-  await dependencies.db.storeRepository(owner, repository);
+  if (
+    owner != null &&
+    owner.length > 0 &&
+    repository != null &&
+    repository.length > 0
+  ) {
+    await dependencies.db.storeRepository(owner, repository);
+  }
   res.writeHead(301, {
     Location: "/admin/repositories",
   });


### PR DESCRIPTION
This PR fixes a bug that allowed for creating a repository with an empty owner or repository name (or both).

closes #401 
