### PR TITLE
♻️ Creating tables now on first connection

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -3,6 +3,7 @@ const moment = require("moment");
 
 let pool;
 let systemLogger = null;
+let createdTables = false;
 
 /**
  * start
@@ -34,13 +35,15 @@ async function start(conf, logger) {
 
   pool.on("connect", (client) => {
     systemLogger.info("Database Connected");
+    if (createdTables === false) {
+      createTables(client);
+      createdTables = true;
+    }
   });
 
   pool.on("error", (error, client) => {
     systemLogger.error("Database error: " + error);
   });
-
-  await createTables();
 }
 
 /**
@@ -786,17 +789,19 @@ async function removeRepository(owner, repository) {
 /**
  * createTables
  */
-async function createTables() {
-  await pool.query("CREATE SCHEMA IF NOT EXISTS stampede;");
+async function createTables(client) {
+  systemLogger.info("Creating stampede database schema");
 
-  await pool.query(
+  client.query("CREATE SCHEMA IF NOT EXISTS stampede;");
+
+  client.query(
     "CREATE TABLE IF NOT EXISTS stampede.repositories \
     (owner varchar, \
       repository varchar, \
     PRIMARY KEY (owner, repository));"
   );
 
-  await pool.query(
+  client.query(
     "CREATE TABLE IF NOT EXISTS stampede.builds \
     (build_id varchar, \
       owner varchar, \
@@ -809,7 +814,7 @@ async function createTables() {
     PRIMARY KEY (build_id));"
   );
 
-  await pool.query(
+  client.query(
     "CREATE TABLE IF NOT EXISTS stampede.tasks \
     (task_id varchar, \
       build_id varchar, \
@@ -824,19 +829,19 @@ async function createTables() {
       PRIMARY KEY (task_id));"
   );
 
-  await pool.query(
+  client.query(
     "CREATE TABLE IF NOT EXISTS stampede.taskDetails \
     (task_id varchar, \
       details jsonb, \
       PRIMARY KEY (task_id));"
   );
 
-  await pool.query(
+  client.query(
     "CREATE TABLE IF NOT EXISTS stampede.version \
     (version int);"
   );
-  await pool.query("DELETE FROM stampede.version;");
-  await pool.query("INSERT into stampede.version (version) VALUES (1);");
+  client.query("DELETE FROM stampede.version;");
+  client.query("INSERT into stampede.version (version) VALUES (1);");
 }
 
 module.exports.start = start;


### PR DESCRIPTION
This PR changes when the tables are created. Now the server will attempt to create them when the first database connection is successful. As the db might not be immediately available when the server starts, this lets the server still start and then once the db is available it should create the tables and then function correctly.

closes #406 