### PR TITLE
🐛 Addressed bug in access token

### DIFF
--- a/controllers/history/requeueTask.js
+++ b/controllers/history/requeueTask.js
@@ -42,7 +42,7 @@ async function handle(req, res, dependencies, owners) {
 
     const accessToken = await dependencies.scm.getAccessToken(
       build.owner,
-      build.repo,
+      build.repository,
       dependencies.serverConfig
     );
     taskDetails.scm.accessToken = accessToken;

--- a/controllers/repositories/requeueTask.js
+++ b/controllers/repositories/requeueTask.js
@@ -42,7 +42,7 @@ async function handle(req, res, dependencies, owners) {
 
     const accessToken = await dependencies.scm.getAccessToken(
       build.owner,
-      build.repo,
+      build.repository,
       dependencies.serverConfig
     );
     taskDetails.scm.accessToken = accessToken;

--- a/scm/github.js
+++ b/scm/github.js
@@ -80,6 +80,7 @@ async function getAuthorizedOctokit(owner, repo, serverConf) {
 }
 
 async function getAccessToken(owner, repo, serverConf) {
+  systemLogger.verbose("Getting access token for " + owner + " " + repo);
   try {
     const app = new App({
       id: serverConf.githubAppID,
@@ -106,8 +107,10 @@ async function getAccessToken(owner, repo, serverConf) {
     const accessToken = await app.getInstallationAccessToken({
       installationId: installID,
     });
+    systemLogger.verbose("Received access token: " + accessToken);
     return accessToken;
   } catch (e) {
+    systemLogger.verbose("Error getting access token: " + e);
     return null;
   }
 }


### PR DESCRIPTION
This PR addresses a bug in the access token creation for re-queued tasks. Also adds some verbose logging to show any access token creation errors.

closes #411 and closes #407 