### PR TITLE
🐛 Prevent large amounts of text to error when updating PR check

### DIFF
--- a/scm/github.js
+++ b/scm/github.js
@@ -292,6 +292,13 @@ async function getTagInfo(owner, repo, ref, serverConf) {
  */
 async function updateCheck(owner, repo, serverConf, update) {
   const authorizedOctokit = await getAuthorizedOctokit(owner, repo, serverConf);
+
+  // Ensure text property can fit in github check
+  if (update.output.text.length > 65535) {
+    update.output.text =
+      "Text too large for GitHub check, contact your stampede admin.";
+  }
+
   await authorizedOctokit.checks.update(update).catch((error) => {
     systemLogger.error("Error updating check in Github: " + error);
     if (update.output.summary != null) {


### PR DESCRIPTION
This PR looks for very large text before trying to update the PR check. If the value is above the GitHub limit, an error message is specified instead.

closes #422 
