### PR TITLE
♻️ reworked repository builds flow from repository details

### DIFF
--- a/controllers/repositories/repositoryBuildDetails.js
+++ b/controllers/repositories/repositoryBuildDetails.js
@@ -1,0 +1,70 @@
+const prettyMilliseconds = require("pretty-ms");
+
+/**
+ * path this handler will serve
+ */
+function path() {
+  return "/repositories/repositoryBuildDetails";
+}
+
+/**
+ * handle index
+ * @param {*} req
+ * @param {*} res
+ * @param {*} dependencies
+ */
+async function handle(req, res, dependencies, owners) {
+  const owner = req.query.owner;
+  const repository = req.query.repository;
+  const build = req.query.build;
+
+  const activeBuilds = await dependencies.db.activeBuilds(owner, repository);
+  let foundActiveBuild = false;
+  for (let bindex = 0; bindex < activeBuilds.rows.length; bindex++) {
+    if (activeBuilds.rows[bindex].build_key === build) {
+      foundActiveBuild = true;
+    }
+  }
+
+  const buildDetails = await dependencies.cache.repositoryBuilds.fetchRepositoryBuild(
+    owner,
+    repository,
+    build
+  );
+  let status = "idle";
+  let message = "";
+  if (buildDetails.schedule != null) {
+    status = "scheduled";
+    message =
+      "⏰ Build is scheduled to run at " +
+      buildDetails.schedule.hour.toString() +
+      ":" +
+      buildDetails.schedule.minute.toString() +
+      " every day";
+  }
+  if (foundActiveBuild) {
+    message = "🐎 Currently running";
+    status = "active";
+  }
+
+  const recentBuilds = await dependencies.db.recentBuilds(
+    "Last 7 Days",
+    build,
+    owner + "/" + repository
+  );
+
+  res.render(dependencies.viewsPath + "repositories/repositoryBuildDetails", {
+    owners: owners,
+    isAdmin: req.validAdminSession,
+    owner: owner,
+    repository: repository,
+    build: build,
+    status: status,
+    message: message,
+    recentBuilds: recentBuilds.rows,
+    prettyMilliseconds: (ms) => (ms != null ? prettyMilliseconds(ms) : ""),
+  });
+}
+
+module.exports.path = path;
+module.exports.handle = handle;

--- a/lib/db.js
+++ b/lib/db.js
@@ -820,6 +820,19 @@ async function removeRepository(owner, repository) {
   return await execute("removeRepository", query, [owner, repository]);
 }
 
+async function mostRecentBuild(owner, repository, build_key) {
+  let query =
+    "SELECT * from stampede.builds WHERE owner = $1 \
+  AND repository = $2 \
+  AND build_key = $3 \
+  ORDER BY started_at DESC LIMIT 1";
+  return await execute("mostRecentBuild", query, [
+    owner,
+    repository,
+    build_key,
+  ]);
+}
+
 /**
  * createTables
  */
@@ -924,3 +937,4 @@ module.exports.removeRepositoryTaskDetails = removeRepositoryTaskDetails;
 module.exports.removeRepositoryTasks = removeRepositoryTasks;
 module.exports.removeRepositoryBuilds = removeRepositoryBuilds;
 module.exports.removeRepository = removeRepository;
+module.exports.mostRecentBuild = mostRecentBuild;

--- a/views/components/tableUnderlinedCell.pug
+++ b/views/components/tableUnderlinedCell.pug
@@ -1,0 +1,2 @@
+mixin tableUnderlinedCell(value)
+    td(class="border px-2 py-2 underline")= value

--- a/views/repositories/repositoryBuildDetails.pug
+++ b/views/repositories/repositoryBuildDetails.pug
@@ -1,0 +1,52 @@
+extends ../layout
+include ../components/titleBar
+include ../components/tableHeader
+include ../components/tableCell
+include ../components/tableUnderlinedCell
+include ../components/tableRow
+include ../components/tableCellButton
+include ../components/formFile
+include ../components/formHidden
+
+block content
+
+  +titleBar([{title: 'Repositories', href: `/repositories?owner=` + owner + `&=` + repository},
+    {title: owner + ' ' + repository, href: '/repositories/repositoryDetails?owner=' + owner + '&repository=' + repository},
+    {title: build}])
+  div(class="flex flex-wrap m-4")
+
+    div(class="w-full p-3")
+        div(class="bg-white border-transparent rounded-lg shadow-lg")
+          div(class="bg-gray-400 uppercase text-gray-800 border-b-2 border-gray-500 rounded-tl-lg rounded-tr-lg p-2")
+            h5(class="font-bold uppercase text-gray-600") Build Details
+          div(class="p-5")
+              table(class="table-auto w-full")
+                tbody
+                  +tableRow()
+                    +tableCell('Build')
+                    +tableCell(build)
+                  if status != "idle"
+                    +tableRow()
+                      +tableCell('Status')
+                      +tableCell(message)
+                  if status == "idle"
+                    +tableRow()
+                      +tableCellButton("Start", `/repositories/executeRepositoryBuild?owner=` + owner + `&repository=` + repository + `&build=` + build)                      
+                      +tableCell("")
+
+    div(class="w-full p-3")
+        div(class="bg-white border-transparent rounded-lg shadow-lg")
+          div(class="bg-gray-400 uppercase text-gray-800 border-b-2 border-gray-500 rounded-tl-lg rounded-tr-lg p-2")
+            h5(class="font-bold uppercase text-gray-600") Recent Builds
+          div(class="p-5")
+            table(class="table-auto w-full")
+                thead
+                  +tableHeader('Build')
+                  +tableHeader('Build #')
+                  +tableHeader('Completed At')
+                each build, i in recentBuilds
+                  tbody
+                    +tableRow(`/repositories/buildDetails?buildID=` + build.build_id)
+                      +tableUnderlinedCell(build.build_key)
+                      +tableCell(build.build)
+                      +tableCell(build.completed_at)

--- a/views/repositories/repositoryDetails.pug
+++ b/views/repositories/repositoryDetails.pug
@@ -2,6 +2,7 @@ extends ../layout
 include ../components/titleBar
 include ../components/tableHeader
 include ../components/tableCell
+include ../components/tableUnderlinedCell
 include ../components/tableRow
 include ../components/tableCellButton
 include ../components/formFile
@@ -27,7 +28,7 @@ block content
                   each build, i in activeBuilds
                     tbody
                         +tableRow(`/repositories/buildDetails?buildID=`+build.build_id)
-                          +tableCell(build.build_key)
+                          +tableUnderlinedCell(build.build_key)
                           +tableCell(build.build)
                           +tableCell(prettyMilliseconds(new Date() - build.started_at))
             else
@@ -41,33 +42,10 @@ block content
             table(class="table-auto w-full")
                 thead
                   +tableHeader('Build')
+                  +tableHeader('Last Executed')
                 each build, i in repositoryBuilds
                   tbody
-                    if build.status == "active" 
-                      +tableRow(`/repositories/buildDetails?buildID=`+build.buildID)
-                        +tableCell(build.build)
-                        +tableCell('🐎 Currently running, click for build details')
-                    else
-                      +tableRow()
-                        +tableCell(build.build)
-                        if build.status == "scheduled"
-                          +tableCell(build.message)
-                        else 
-                          +tableCellButton("Start", `/repositories/executeRepositoryBuild?owner=` + owner + `&repository=` + repository + `&build=` + build.build)
+                    +tableRow(`/repositories/repositoryBuildDetails?owner=` + owner + `&repository=` + repository + `&build=` + build.build)
+                      +tableUnderlinedCell(build.build, "underline")
+                      +tableCell(build.message, "underline")
 
-    div(class="w-full p-3")
-        div(class="bg-white border-transparent rounded-lg shadow-lg")
-          div(class="bg-gray-400 uppercase text-gray-800 border-b-2 border-gray-500 rounded-tl-lg rounded-tr-lg p-2")
-            h5(class="font-bold uppercase text-gray-600") Recent Builds
-          div(class="p-5")
-            table(class="table-auto w-full")
-                thead
-                  +tableHeader('Build')
-                  +tableHeader('Build #')
-                  +tableHeader('Completed At')
-                each build, i in recentBuilds
-                  tbody
-                    +tableRow(`/repositories/buildDetails?buildID=` + build.build_id)
-                      +tableCell(build.build_key)
-                      +tableCell(build.build)
-                      +tableCell(build.completed_at)


### PR DESCRIPTION
This PR reworks the repository build list on the repository details screen. Now the list will show an entry for each build that has been defined, and provides a link to a details page. The start button has moved to the details page. Also on the details page are the recents for that particular build. Now it is easier to find the results of a particular repository build. This may confuse users at first, but hopefully this works better in the long run since it allows for easily finding the recents for each of these manual/scheduled builds.

closes #418 