### PR TITLE
✨ Added config option for response handler

### DIFF
--- a/.ubolt.yaml
+++ b/.ubolt.yaml
@@ -9,6 +9,9 @@ version:
 runlocal:
   command: bin/stampede-server.js --config .stampederc-local
   description: Run the stampede server against a local instance of redis/postgres running in docker
+runresponse:
+  command: bin/stampede-server.js --config .stampederc-response
+  description: Run the stampede server against a local instance of redis/postgres running in docker
 dockerpush:
   commands:
     - docker build -t davidahouse/stampede-server .

--- a/lib/web.js
+++ b/lib/web.js
@@ -17,8 +17,8 @@ function startRESTApi(dependencies) {
   // If we don't have any web enabled, we can just exit
   console.dir(dependencies.serverConfig);
   if (
-    dependencies.serverConfig.enablePortal != true &&
-    dependencies.serverConfig.enableIncoming != true
+    dependencies.serverConfig.handlePortal != "enabled" &&
+    dependencies.serverConfig.handleIncoming != "enabled"
   ) {
     dependencies.logger.info(
       "Neither portal or incoming enabled so now web port is started"
@@ -40,13 +40,13 @@ function startRESTApi(dependencies) {
   app.use(fileUpload());
 
   let port = process.env.PORT || dependencies.serverConfig.webPort;
-  if (dependencies.serverConfig.enablePortal === true) {
+  if (dependencies.serverConfig.handlePortal === "enabled") {
     const apiRouter = api.router(dependencies);
     app.use(apiRouter);
     const uiRouter = ui.router(dependencies);
     app.use(uiRouter);
   }
-  if (dependencies.serverConfig.enableIncoming === true) {
+  if (dependencies.serverConfig.handleIncoming === "enabled") {
     const incomingRouter = incoming.router(dependencies);
     app.use(incomingRouter);
   }


### PR DESCRIPTION
This PR adds a config option to disable the response queue handler. This is part of the series of enable config options for disabling certain parts of the server when you want to spread the work across different instances of the server.

closes #434 
