### PR TITLE
✨ Added incoming queue for handling github events

### DIFF
--- a/events/checkRun.js
+++ b/events/checkRun.js
@@ -5,13 +5,13 @@ const notification = require("../lib/notification");
 
 /**
  * handle event
- * @param {*} req
+ * @param {*} body
  * @param {*} serverConf
  * @param {*} cache
  */
-async function handle(req, serverConf, cache, scm, db, logger) {
+async function handle(body, serverConf, cache, scm, db, logger) {
   // Parse the incoming body into the parts we care about
-  const event = parseEvent(req);
+  const event = parseEvent(body);
   logger.info("CheckRunEvent:");
   if (serverConf.logLevel === "verbose") {
     logger.verbose(JSON.stringify(event, null, 2));
@@ -68,35 +68,35 @@ async function handle(req, serverConf, cache, scm, db, logger) {
 
 /**
  * parse body into an event object
- * @param {*} req
+ * @param {*} body
  * @return {object} event
  */
-function parseEvent(req) {
-  const fullName = req.body.repository.full_name;
+function parseEvent(body) {
+  const fullName = body.repository.full_name;
   const parts = fullName.split("/");
   const owner = parts[0];
   const repo = parts[1];
 
   let actionID = null;
-  if (req.body.requested_action != null) {
-    actionID = req.body.requested_action.identifier;
+  if (body.requested_action != null) {
+    actionID = body.requested_action.identifier;
   }
 
   return {
-    appID: req.body.check_run.app.id,
+    appID: body.check_run.app.id,
     owner: owner,
     repo: repo,
-    action: req.body.action,
+    action: body.action,
     pullRequests:
-      req.body.check_run.check_suite.pull_requests != null
-        ? req.body.check_run.check_suite.pull_requests
+      body.check_run.check_suite.pull_requests != null
+        ? body.check_run.check_suite.pull_requests
         : [],
-    sha: req.body.check_run.head_sha,
-    cloneURL: req.body.repository.clone_url,
-    sshURL: req.body.repository.ssh_url,
-    checkRunID: req.body.check_run.id,
-    externalID: req.body.check_run.external_id,
-    actionID: actionID
+    sha: body.check_run.head_sha,
+    cloneURL: body.repository.clone_url,
+    sshURL: body.repository.ssh_url,
+    checkRunID: body.check_run.id,
+    externalID: body.check_run.external_id,
+    actionID: actionID,
   };
 }
 

--- a/events/checkSuite.js
+++ b/events/checkSuite.js
@@ -5,14 +5,14 @@ const notification = require("../lib/notification");
 
 /**
  * handle event
- * @param {*} req
+ * @param {*} body
  * @param {*} serverConf
  * @param {*} cache
  * @return {Object} response to the event
  */
-async function handle(req, serverConf, cache, scm, db, logger) {
+async function handle(body, serverConf, cache, scm, db, logger) {
   // Parse the incoming body into the parts we care about
-  const event = parseEvent(req);
+  const event = parseEvent(body);
   logger.info("CheckSuiteEvent:");
   if (serverConf.logLevel === "verbose") {
     logger.verbose(JSON.stringify(event, null, 2));
@@ -52,26 +52,26 @@ async function handle(req, serverConf, cache, scm, db, logger) {
 
 /**
  * parse body into an event object
- * @param {*} req
+ * @param {*} body
  * @return {object} event
  */
-function parseEvent(req) {
-  const fullName = req.body.repository.full_name;
+function parseEvent(body) {
+  const fullName = body.repository.full_name;
   const parts = fullName.split("/");
   const owner = parts[0];
   const repo = parts[1];
   return {
-    appID: req.body.check_suite.app.id,
+    appID: body.check_suite.app.id,
     owner: owner,
     repo: repo,
-    action: req.body.action,
+    action: body.action,
     pullRequests:
-      req.body.check_suite.pull_requests != null
-        ? req.body.check_suite.pull_requests
+      body.check_suite.pull_requests != null
+        ? body.check_suite.pull_requests
         : [],
-    sha: req.body.check_suite.head_sha,
-    cloneURL: req.body.repository.clone_url,
-    sshURL: req.body.repository.ssh_url
+    sha: body.check_suite.head_sha,
+    cloneURL: body.repository.clone_url,
+    sshURL: body.repository.ssh_url,
   };
 }
 

--- a/events/pullRequest.js
+++ b/events/pullRequest.js
@@ -7,13 +7,13 @@ const build = require("../lib/build");
 
 /**
  * handle event
- * @param {*} req
+ * @param {*} body
  * @param {*} serverConf
  * @param {*} cache
  */
-async function handle(req, serverConf, cache, scm, db, logger) {
+async function handle(body, serverConf, cache, scm, db, logger) {
   // Parse the incoming body into the parts we care about
-  const event = parseEvent(req);
+  const event = parseEvent(body);
   logger.info("PullRequestEvent:");
   if (serverConf.logLevel === "verbose") {
     logger.verbose(JSON.stringify(event, null, 2));
@@ -62,28 +62,28 @@ async function handle(req, serverConf, cache, scm, db, logger) {
 
 /**
  * parse body into an event object
- * @param {*} req
+ * @param {*} body
  * @return {object} event
  */
-function parseEvent(req) {
-  const fullName = req.body.repository.full_name;
+function parseEvent(body) {
+  const fullName = body.repository.full_name;
   const parts = fullName.split("/");
   const owner = parts[0];
   const repo = parts[1];
   return {
     owner: owner,
     repo: repo,
-    action: req.body.action,
-    pullRequest: req.body.pull_request,
-    sha: req.body.pull_request.head.sha,
+    action: body.action,
+    pullRequest: body.pull_request,
+    sha: body.pull_request.head.sha,
     cloneURL:
-      req.body.pull_request.head.repo.clone_url != null
-        ? req.body.pull_request.head.repo.clone_url
-        : req.body.repository.clone_url,
+      body.pull_request.head.repo.clone_url != null
+        ? body.pull_request.head.repo.clone_url
+        : body.repository.clone_url,
     sshURL:
-      req.body.pull_request.head.repo.ssh_url != null
-        ? req.body.pull_request.head.repo.ssh_url
-        : req.body.repository.ssh_url,
+      body.pull_request.head.repo.ssh_url != null
+        ? body.pull_request.head.repo.ssh_url
+        : body.repository.ssh_url,
   };
 }
 

--- a/events/push.js
+++ b/events/push.js
@@ -8,13 +8,13 @@ const notification = require("../lib/notification");
 
 /**
  * handle event
- * @param {*} req
+ * @param {*} body
  * @param {*} serverConf
  * @param {*} cache
  */
-async function handle(req, serverConf, cache, scm, db, logger) {
+async function handle(body, serverConf, cache, scm, db, logger) {
   // Parse the incoming body into the parts we care about
-  const event = parseEvent(req);
+  const event = parseEvent(body);
   logger.info("PushEvent:");
   notification.repositoryEventReceived("push", event);
 
@@ -97,26 +97,26 @@ async function handle(req, serverConf, cache, scm, db, logger) {
 
 /**
  * parse body into an event object
- * @param {*} req
+ * @param {*} body
  * @return {object} event
  */
-function parseEvent(req) {
-  const fullName = req.body.repository.full_name;
+function parseEvent(body) {
+  const fullName = body.repository.full_name;
   const parts = fullName.split("/");
   const owner = parts[0];
   const repo = parts[1];
   return {
     owner: owner,
     repo: repo,
-    created: req.body.created,
-    deleted: req.body.deleted,
-    branch: req.body.ref.replace("refs/heads/", ""),
-    sha: req.body.after,
-    cloneURL: req.body.repository.clone_url,
-    sshURL: req.body.repository.ssh_url,
+    created: body.created,
+    deleted: body.deleted,
+    branch: body.ref.replace("refs/heads/", ""),
+    sha: body.after,
+    cloneURL: body.repository.clone_url,
+    sshURL: body.repository.ssh_url,
     commitMessage:
-      req.body.head_commit != null && req.body.head_commit.message != null
-        ? req.body.head_commit.message
+      body.head_commit != null && body.head_commit.message != null
+        ? body.head_commit.message
         : "",
   };
 }

--- a/events/release.js
+++ b/events/release.js
@@ -13,9 +13,9 @@ const notification = require("../lib/notification");
  * @param {*} cache
  * @param {*} scm
  */
-async function handle(req, serverConf, cache, scm, db, logger) {
+async function handle(body, serverConf, cache, scm, db, logger) {
   // Parse the incoming body into the parts we care about
-  const event = parseEvent(req);
+  const event = parseEvent(body);
   logger.info("ReleaseEvent:");
   notification.repositoryEventReceived("release", event);
 
@@ -125,28 +125,28 @@ async function handle(req, serverConf, cache, scm, db, logger) {
 
 /**
  * parse body into an event object
- * @param {*} req
+ * @param {*} body
  * @return {object} event
  */
-function parseEvent(req) {
-  const fullName = req.body.repository.full_name;
+function parseEvent(body) {
+  const fullName = body.repository.full_name;
   const parts = fullName.split("/");
   const owner = parts[0];
   const repo = parts[1];
   return {
     owner: owner,
     repo: repo,
-    action: req.body.action,
-    created: req.body.created,
-    deleted: req.body.deleted,
-    release: req.body.release.name,
-    tag: req.body.release.tag_name,
-    cloneURL: req.body.repository.clone_url,
-    sshURL: req.body.repository.ssh_url,
-    prerelease: req.body.release.prerelease,
-    body: req.body.release.body,
-    draft: req.body.release.draft,
-    target: req.body.release.target_commitish,
+    action: body.action,
+    created: body.created,
+    deleted: body.deleted,
+    release: body.release.name,
+    tag: body.release.tag_name,
+    cloneURL: body.repository.clone_url,
+    sshURL: body.repository.ssh_url,
+    prerelease: body.release.prerelease,
+    body: body.release.body,
+    draft: body.release.draft,
+    target: body.release.target_commitish,
   };
 }
 

--- a/lib/incomingHandler.js
+++ b/lib/incomingHandler.js
@@ -1,0 +1,71 @@
+"use strict";
+
+// Event handlers
+const checkSuiteEvent = require("../events/checkSuite");
+const checkRunEvent = require("../events/checkRun");
+const pullRequestEvent = require("../events/pullRequest");
+const pushEvent = require("../events/push");
+const releaseEvent = require("../events/release");
+
+/**
+ * handle task update
+ * @param {*} job
+ * @param {*} conf
+ * @param {*} cache
+ * @param {*} scm
+ * @param {*} db
+ */
+async function handle(job, dependencies) {
+  try {
+    if (job.event === "check_suite") {
+      await checkSuiteEvent.handle(
+        job.body,
+        dependencies.serverConfig,
+        dependencies.cache,
+        dependencies.scm,
+        dependencies.db,
+        dependencies.logger
+      );
+    } else if (job.event === "check_run") {
+      await checkRunEvent.handle(
+        job.body,
+        dependencies.serverConfig,
+        dependencies.cache,
+        dependencies.scm,
+        dependencies.db,
+        dependencies.logger
+      );
+    } else if (job.event === "pull_request") {
+      await pullRequestEvent.handle(
+        job.body,
+        dependencies.serverConfig,
+        dependencies.cache,
+        dependencies.scm,
+        dependencies.db,
+        dependencies.logger
+      );
+    } else if (job.event === "push") {
+      await pushEvent.handle(
+        job.body,
+        dependencies.serverConfig,
+        dependencies.cache,
+        dependencies.scm,
+        dependencies.db,
+        dependencies.logger
+      );
+    } else if (job.event === "release") {
+      await releaseEvent.handle(
+        job.body,
+        dependencies.serverConfig,
+        dependencies.cache,
+        dependencies.scm,
+        dependencies.db,
+        dependencies.logger
+      );
+    }
+  } catch (e) {
+    dependencies.logger.error("Error handling incoming message: " + e);
+  }
+}
+
+module.exports.handle = handle;


### PR DESCRIPTION
This PR adds an incoming queue where GitHub events are placed and then handled separately. This should keep the reception of events fast so GitHub doesn't timeout and we lose a message. A config option is also available for disabling the incoming handling if you have instances of the server that shouldn't perform that work.

closes #425