### PR TITLE
✨Retention policy handler

### DIFF
--- a/bin/stampede-server.js
+++ b/bin/stampede-server.js
@@ -67,6 +67,10 @@ const conf = require("rc")("stampede", {
   adminPassword: "stampede",
   // Logging
   logLevel: "info",
+  // Retention
+  defaultBuildRetentionDays: 30,
+  defaultReleaseBuildRetentionDays: 3000,
+  cleanupArtifactTask: null,
 });
 
 // Configure winston logging

--- a/bin/stampede-server.js
+++ b/bin/stampede-server.js
@@ -15,8 +15,9 @@ const taskQueue = require("../lib/taskQueue");
 const taskUpdate = require("../lib/taskUpdate");
 const notification = require("../lib/notification");
 const db = require("../lib/db");
-const repositoryBuild = require("../lib/repositoryBuild");
 const incomingHandler = require("../lib/incomingHandler");
+const retentionHandler = require("../lib/retentionHandler");
+const buildScheduleHandler = require("../lib/buildScheduleHandler");
 
 const fiveMinuteInterval = 1000 * 60 * 5;
 const conf = require("rc")("stampede", {
@@ -57,6 +58,8 @@ const conf = require("rc")("stampede", {
   handleResponseQueue: "enabled",
   // Control if the server looks for builds that need to be auto-started
   handleBuildScheduler: "enabled",
+  // Control if the server executes the retention policy handler
+  handleRetentionScheduler: "enabled",
   // Debug assist properties
   logEventPath: null,
   testModeRepoConfigPath: null,
@@ -207,70 +210,20 @@ async function gracefulShutdown() {
 
 db.start(conf, logger);
 
-if (conf.handleBuildScheduler === "enabled") {
+if (
+  conf.handleBuildScheduler === "enabled" ||
+  conf.handleRetentionScheduler === "enabled"
+) {
   setInterval(buildSchedule, fiveMinuteInterval);
+}
 
-  async function buildSchedule() {
-    const currentDate = new Date();
-    logger.verbose(
-      "Checking for any builds that need to be started at hour " +
-        currentDate.getHours() +
-        " minute " +
-        currentDate.getMinutes()
-    );
-    // loop through any scheduled builds defined in the system
-    // check the last run date and if a different date then check time
-    // if we have passed the time to start the build, start it!
-    const repositories = await db.fetchRepositories();
-    for (let index = 0; index < repositories.rows.length; index++) {
-      const repositoryBuilds = await cache.repositoryBuilds.fetchRepositoryBuilds(
-        repositories.rows[index].owner,
-        repositories.rows[index].repository
-      );
-      if (repositoryBuilds != null) {
-        for (
-          let buildIndex = 0;
-          buildIndex < repositoryBuilds.length;
-          buildIndex++
-        ) {
-          const buildInfo = await cache.repositoryBuilds.fetchRepositoryBuild(
-            repositories.rows[index].owner,
-            repositories.rows[index].repository,
-            repositoryBuilds[buildIndex]
-          );
-          if (
-            buildInfo.schedule != null &&
-            (buildInfo.lastExecuteDate == null ||
-              new Date(buildInfo.lastExecuteDate).getDate() !=
-                currentDate.getDate() ||
-              new Date(buildInfo.lastExecuteDate).getMonth() !=
-                currentDate.getMonth() ||
-              new Date(buildInfo.lastExecuteDate).getFullYear() !=
-                currentDate.getFullYear())
-          ) {
-            if (
-              currentDate.getHours() >= buildInfo.schedule.hour &&
-              currentDate.getMinutes() >= buildInfo.schedule.minute
-            ) {
-              logger.verbose("Executing a repository build:");
-              buildInfo.lastExecuteDate = currentDate;
-              await cache.repositoryBuilds.updateRepositoryBuild(
-                repositories.rows[index].owner,
-                repositories.rows[index].repository,
-                buildInfo
-              );
-              repositoryBuild.execute(
-                repositories.rows[index].owner,
-                repositories.rows[index].repository,
-                repositoryBuilds[buildIndex],
-                buildInfo,
-                dependencies
-              );
-            }
-          }
-        }
-      }
-    }
+async function buildSchedule() {
+  if (conf.handleBuildScheduler === "enabled") {
+    await buildScheduleHandler.handle(dependencies);
+  }
+
+  if (conf.handleRetentionScheduler === "enabled") {
+    await retentionHandler.handle(dependencies);
   }
 }
 

--- a/lib/buildScheduleHandler.js
+++ b/lib/buildScheduleHandler.js
@@ -1,0 +1,66 @@
+const repositoryBuild = require("repositoryBuild");
+
+async function handle(dependencies) {
+  const currentDate = new Date();
+  logger.verbose(
+    "Checking for any builds that need to be started at hour " +
+      currentDate.getHours() +
+      " minute " +
+      currentDate.getMinutes()
+  );
+  // loop through any scheduled builds defined in the system
+  // check the last run date and if a different date then check time
+  // if we have passed the time to start the build, start it!
+  const repositories = await dependencies.db.fetchRepositories();
+  for (let index = 0; index < repositories.rows.length; index++) {
+    const repositoryBuilds = await cache.repositoryBuilds.fetchRepositoryBuilds(
+      repositories.rows[index].owner,
+      repositories.rows[index].repository
+    );
+    if (repositoryBuilds != null) {
+      for (
+        let buildIndex = 0;
+        buildIndex < repositoryBuilds.length;
+        buildIndex++
+      ) {
+        const buildInfo = await dependencies.cache.repositoryBuilds.fetchRepositoryBuild(
+          repositories.rows[index].owner,
+          repositories.rows[index].repository,
+          repositoryBuilds[buildIndex]
+        );
+        if (
+          buildInfo.schedule != null &&
+          (buildInfo.lastExecuteDate == null ||
+            new Date(buildInfo.lastExecuteDate).getDate() !=
+              currentDate.getDate() ||
+            new Date(buildInfo.lastExecuteDate).getMonth() !=
+              currentDate.getMonth() ||
+            new Date(buildInfo.lastExecuteDate).getFullYear() !=
+              currentDate.getFullYear())
+        ) {
+          if (
+            currentDate.getHours() >= buildInfo.schedule.hour &&
+            currentDate.getMinutes() >= buildInfo.schedule.minute
+          ) {
+            logger.verbose("Executing a repository build:");
+            buildInfo.lastExecuteDate = currentDate;
+            await dependencies.cache.repositoryBuilds.updateRepositoryBuild(
+              repositories.rows[index].owner,
+              repositories.rows[index].repository,
+              buildInfo
+            );
+            repositoryBuild.execute(
+              repositories.rows[index].owner,
+              repositories.rows[index].repository,
+              repositoryBuilds[buildIndex],
+              buildInfo,
+              dependencies
+            );
+          }
+        }
+      }
+    }
+  }
+}
+
+module.exports.handle = handle;

--- a/lib/buildScheduleHandler.js
+++ b/lib/buildScheduleHandler.js
@@ -1,65 +1,69 @@
-const repositoryBuild = require("repositoryBuild");
+const repositoryBuild = require("./repositoryBuild");
 
 async function handle(dependencies) {
-  const currentDate = new Date();
-  logger.verbose(
-    "Checking for any builds that need to be started at hour " +
-      currentDate.getHours() +
-      " minute " +
-      currentDate.getMinutes()
-  );
-  // loop through any scheduled builds defined in the system
-  // check the last run date and if a different date then check time
-  // if we have passed the time to start the build, start it!
-  const repositories = await dependencies.db.fetchRepositories();
-  for (let index = 0; index < repositories.rows.length; index++) {
-    const repositoryBuilds = await cache.repositoryBuilds.fetchRepositoryBuilds(
-      repositories.rows[index].owner,
-      repositories.rows[index].repository
+  try {
+    const currentDate = new Date();
+    dependencies.logger.verbose(
+      "Checking for any builds that need to be started at hour " +
+        currentDate.getHours() +
+        " minute " +
+        currentDate.getMinutes()
     );
-    if (repositoryBuilds != null) {
-      for (
-        let buildIndex = 0;
-        buildIndex < repositoryBuilds.length;
-        buildIndex++
-      ) {
-        const buildInfo = await dependencies.cache.repositoryBuilds.fetchRepositoryBuild(
-          repositories.rows[index].owner,
-          repositories.rows[index].repository,
-          repositoryBuilds[buildIndex]
-        );
-        if (
-          buildInfo.schedule != null &&
-          (buildInfo.lastExecuteDate == null ||
-            new Date(buildInfo.lastExecuteDate).getDate() !=
-              currentDate.getDate() ||
-            new Date(buildInfo.lastExecuteDate).getMonth() !=
-              currentDate.getMonth() ||
-            new Date(buildInfo.lastExecuteDate).getFullYear() !=
-              currentDate.getFullYear())
+    // loop through any scheduled builds defined in the system
+    // check the last run date and if a different date then check time
+    // if we have passed the time to start the build, start it!
+    const repositories = await dependencies.db.fetchRepositories();
+    for (let index = 0; index < repositories.rows.length; index++) {
+      const repositoryBuilds = await dependencies.cache.repositoryBuilds.fetchRepositoryBuilds(
+        repositories.rows[index].owner,
+        repositories.rows[index].repository
+      );
+      if (repositoryBuilds != null) {
+        for (
+          let buildIndex = 0;
+          buildIndex < repositoryBuilds.length;
+          buildIndex++
         ) {
+          const buildInfo = await dependencies.cache.repositoryBuilds.fetchRepositoryBuild(
+            repositories.rows[index].owner,
+            repositories.rows[index].repository,
+            repositoryBuilds[buildIndex]
+          );
           if (
-            currentDate.getHours() >= buildInfo.schedule.hour &&
-            currentDate.getMinutes() >= buildInfo.schedule.minute
+            buildInfo.schedule != null &&
+            (buildInfo.lastExecuteDate == null ||
+              new Date(buildInfo.lastExecuteDate).getDate() !=
+                currentDate.getDate() ||
+              new Date(buildInfo.lastExecuteDate).getMonth() !=
+                currentDate.getMonth() ||
+              new Date(buildInfo.lastExecuteDate).getFullYear() !=
+                currentDate.getFullYear())
           ) {
-            logger.verbose("Executing a repository build:");
-            buildInfo.lastExecuteDate = currentDate;
-            await dependencies.cache.repositoryBuilds.updateRepositoryBuild(
-              repositories.rows[index].owner,
-              repositories.rows[index].repository,
-              buildInfo
-            );
-            repositoryBuild.execute(
-              repositories.rows[index].owner,
-              repositories.rows[index].repository,
-              repositoryBuilds[buildIndex],
-              buildInfo,
-              dependencies
-            );
+            if (
+              currentDate.getHours() >= buildInfo.schedule.hour &&
+              currentDate.getMinutes() >= buildInfo.schedule.minute
+            ) {
+              dependencies.logger.verbose("Executing a repository build:");
+              buildInfo.lastExecuteDate = currentDate;
+              await dependencies.cache.repositoryBuilds.updateRepositoryBuild(
+                repositories.rows[index].owner,
+                repositories.rows[index].repository,
+                buildInfo
+              );
+              repositoryBuild.execute(
+                repositories.rows[index].owner,
+                repositories.rows[index].repository,
+                repositoryBuilds[buildIndex],
+                buildInfo,
+                dependencies
+              );
+            }
           }
         }
       }
     }
+  } catch (e) {
+    dependencies.logger.error("Error in build scheduler handler: " + e);
   }
 }
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -916,7 +916,7 @@ async function removeBuild(build_id) {
 async function buildsForRetention(source, keepDays) {
   let keepDate = moment().subtract(keepDays, "days").toDate();
   let query =
-    "SELECT * from stampede.builds WHERE source = $1 and completed_date < $2 LIMIT 50";
+    "SELECT * from stampede.builds WHERE source = $1 and completed_at < $2 LIMIT 50";
   return await execute("buildsForRetention", query, [source, keepDate]);
 }
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -913,6 +913,13 @@ async function removeBuild(build_id) {
   await execute("removeBuildDeleteBuild", deleteBuild, [build_id]);
 }
 
+async function buildsForRetention(source, keepDays) {
+  let keepDate = moment().subtract(keepDays, "days").toDate();
+  let query =
+    "SELECT * from stampede.builds WHERE source = $1 and completed_date < $2 LIMIT 50";
+  return await execute("buildsForRetention", query, [source, keepDate]);
+}
+
 /**
  * createTables
  */
@@ -1052,3 +1059,4 @@ module.exports.removeRepositoryBuilds = removeRepositoryBuilds;
 module.exports.removeRepository = removeRepository;
 module.exports.mostRecentBuild = mostRecentBuild;
 module.exports.removeBuild = removeBuild;
+module.exports.buildsForRetention = buildsForRetention;

--- a/lib/retentionHandler.js
+++ b/lib/retentionHandler.js
@@ -1,0 +1,25 @@
+async function handle(dependencies) {
+  const pullRequestBuilds = await dependencies.db.buildsForRetention(
+    "pull-request",
+    15
+  );
+  deleteBuilds(pullRequestBuilds);
+  const branchBuilds = await dependencies.db.buildsForRetention(
+    "branch-push",
+    15
+  );
+  const repositoryBuilds = await dependencies.db.buildsForRetention(
+    "repository-build",
+    15
+  );
+  const releaseBuilds = await dependencies.db.buildsForRetention(
+    "release",
+    3000
+  );
+}
+
+async function deleteBuilds(builds, dependencies) {}
+
+async function deleteBuild(build, dependencies) {}
+
+module.exports.handle = handle;

--- a/lib/retentionHandler.js
+++ b/lib/retentionHandler.js
@@ -1,25 +1,135 @@
+const taskDetail = require("./taskDetail");
+const taskQueue = require("./taskQueue");
+
+let cleanupBuild = 1;
+
 async function handle(dependencies) {
-  const pullRequestBuilds = await dependencies.db.buildsForRetention(
-    "pull-request",
-    15
-  );
-  deleteBuilds(pullRequestBuilds);
-  const branchBuilds = await dependencies.db.buildsForRetention(
-    "branch-push",
-    15
-  );
-  const repositoryBuilds = await dependencies.db.buildsForRetention(
-    "repository-build",
-    15
-  );
-  const releaseBuilds = await dependencies.db.buildsForRetention(
-    "release",
-    3000
-  );
+  try {
+    const pullRequestBuilds = await dependencies.db.buildsForRetention(
+      "pull-request",
+      dependencies.serverConfig.defaultBuildRetentionDays
+    );
+    await deleteBuilds(pullRequestBuilds, dependencies);
+
+    const branchBuilds = await dependencies.db.buildsForRetention(
+      "branch-push",
+      dependencies.serverConfig.defaultBuildRetentionDays
+    );
+    await deleteBuilds(branchBuilds, dependencies);
+
+    const repositoryBuilds = await dependencies.db.buildsForRetention(
+      "repository-build",
+      dependencies.serverConfig.defaultBuildRetentionDays
+    );
+    await deleteBuilds(repositoryBuilds, dependencies);
+
+    const releaseBuilds = await dependencies.db.buildsForRetention(
+      "release",
+      dependencies.serverConfig.defaultReleaseBuildRetentionDays
+    );
+    await deleteBuilds(releaseBuilds, dependencies);
+  } catch (e) {
+    dependencies.logger.error("Error in retentionHandler: " + e);
+  }
 }
 
-async function deleteBuilds(builds, dependencies) {}
+async function deleteBuilds(builds, dependencies) {
+  for (let index = 0; index < builds.rows.length; index++) {
+    await deleteBuild(builds.rows[index], dependencies);
+  }
+}
 
-async function deleteBuild(build, dependencies) {}
+async function deleteBuild(build, dependencies) {
+  const artifacts = await fetchBuildArtifacts(build, dependencies);
+  console.log("DELETING ARTIFACTS:");
+  console.dir(artifacts);
+  await queueArtifactCleanupTasks(artifacts, dependencies);
+
+  dependencies.logger.info("DELETING BUILD: " + build.build_id);
+  await dependencies.db.removeBuild(build.build_id);
+}
+
+async function fetchBuildArtifacts(build, dependencies) {
+  const tasks = await dependencies.db.fetchBuildTasks(build.build_id);
+  const artifacts = [];
+  for (let index = 0; index < tasks.rows.length; index++) {
+    const taskDetails = await dependencies.db.fetchTaskDetails(
+      tasks.rows[index].task_id
+    );
+    if (
+      taskDetails.rows.length > 0 &&
+      taskDetails.rows[0].details != null &&
+      taskDetails.rows[0].details.result != null &&
+      taskDetails.rows[0].details.result.artifacts != null
+    ) {
+      for (
+        let aindex = 0;
+        aindex < taskDetails.rows[0].details.result.artifacts.length;
+        aindex++
+      ) {
+        artifacts.push(taskDetails.rows[0].details.result.artifacts[aindex]);
+      }
+    }
+  }
+  return artifacts;
+}
+
+async function queueArtifactCleanupTasks(artifacts, dependencies) {
+  if (dependencies.serverConfig.cleanupArtifactTask == null) {
+    return;
+  }
+
+  const workerConfig = await taskDetail.taskWorkerConfig(
+    dependencies.serverConfig.cleanupArtifactTask,
+    dependencies.cache
+  );
+
+  for (let index = 0; index < artifacts.length; index++) {
+    if (artifacts[index].type === "download") {
+      const taskConfig = {
+        url: {
+          value: artifacts[index].url,
+          source: "repoConfig",
+        },
+      };
+
+      const taskDetails = {
+        owner: "system",
+        repository: "system",
+        buildKey: "cleanup",
+        buildNumber: cleanupBuild.toString(),
+        buildID: "cleanup-" + cleanupBuild.toString(),
+        taskID: dependencies.serverConfig.cleanupArtifactTask,
+        status: "queued",
+        task: {
+          id: dependencies.serverConfig.cleanupArtifactTask,
+          number: "1",
+        },
+        config: taskConfig,
+        workerConfig: workerConfig,
+        scm: {},
+        stats: {
+          queuedAt: Date(),
+        },
+      };
+      cleanupBuild += 1;
+
+      let queueName = await taskDetail.taskQueue(
+        dependencies.serverConfig.cleanupArtifactTask,
+        dependencies.cache
+      );
+      if (queueName != null) {
+        taskDetails.taskQueue = queueName;
+        dependencies.logger.verbose("Adding task to queue: " + queueName);
+        const queue = taskQueue.createTaskQueue("stampede-" + queueName);
+        await queue.add(taskDetails, {
+          removeOnComplete: true,
+          removeOnFail: true,
+        });
+        await queue.close();
+      }
+    }
+  }
+}
 
 module.exports.handle = handle;

--- a/lib/retentionHandler.js
+++ b/lib/retentionHandler.js
@@ -41,8 +41,6 @@ async function deleteBuilds(builds, dependencies) {
 
 async function deleteBuild(build, dependencies) {
   const artifacts = await fetchBuildArtifacts(build, dependencies);
-  console.log("DELETING ARTIFACTS:");
-  console.dir(artifacts);
   await queueArtifactCleanupTasks(artifacts, dependencies);
 
   dependencies.logger.info("DELETING BUILD: " + build.build_id);


### PR DESCRIPTION
This PR updates the server to include a retention policy. Now older builds will be automatically deleted from the system. You can control this behavior using the `defaultBuildRetentionDays` and `defaultReleaseBuildRetentionDays` config values. Release builds are given a separate parameter as generally you want to keep these around much longer. Also you can execute a system task for any artifacts that were captured by the build using the `cleanupArtifactTask` config. This should contain the task ID for the task that you want to run on a worker. The server will queue up a single task execution for each artifact in the build. Also note these cleanup tasks will show up on the worker under the owner/repo of `system/system`. They will not show up in the list of running tasks in the system nor will they report any kind of status.

closes #439 