### PR TITLE
🐛 Fixed release ordering for repository details

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -784,12 +784,11 @@ async function fetchBuildKeys(owner, repository, source) {
     LIMIT 50";
   } else if (source === "release") {
     query =
-      "SELECT DISTINCT build_key from (SELECT build_key FROM stampede.builds \
+      "SELECT build_key FROM stampede.builds \
         WHERE owner = $1 AND \
         repository = $2 AND \
         source = $3 \
-        ORDER BY started_at DESC) b \
-        ORDER BY build_key \
+        ORDER BY started_at DESC \
         LIMIT 10";
   }
   return await execute("fetchBuildKeys", query, [owner, repository, source]);


### PR DESCRIPTION
This PR fixes a bug in the release ordering on the repository details screen.

closes #446 