### PR TITLE
♻️ Changed retention to use archiving instead of deleting

### DIFF
--- a/controllers/history/buildTaskDetails.js
+++ b/controllers/history/buildTaskDetails.js
@@ -18,76 +18,80 @@ async function handle(req, res, dependencies, owners) {
     const detailsRows = await dependencies.db.fetchTaskDetails(
       req.query.taskID
     );
-    const taskDetails = detailsRows.rows[0];
     const configValues = [];
-    if (req.validAdminSession == true) {
-      Object.keys(
-        taskDetails.details.config != null ? taskDetails.details.config : {}
-      ).forEach(function (key) {
-        configValues.push({
-          key: key,
-          value: taskDetails.details.config[key].value,
-          source: taskDetails.details.config[key].source,
+    const scmDetails = [];
+    let artifacts = [];
+    let taskDetails = { details: {} };
+    if (detailsRows.rows.length > 0) {
+      taskDetails = detailsRows.rows[0];
+      if (req.validAdminSession == true) {
+        Object.keys(
+          taskDetails.details.config != null ? taskDetails.details.config : {}
+        ).forEach(function (key) {
+          configValues.push({
+            key: key,
+            value: taskDetails.details.config[key].value,
+            source: taskDetails.details.config[key].source,
+          });
         });
-      });
+      }
+      artifacts =
+        taskDetails.details.result != null &&
+        taskDetails.details.result.artifacts != null
+          ? taskDetails.details.result.artifacts
+          : [];
+
+      if (taskDetails.details.scm.pullRequest != null) {
+        scmDetails.push({
+          title: "PR Number",
+          value: taskDetails.details.scm.pullRequest.number,
+        });
+        scmDetails.push({
+          title: "Head",
+          value: taskDetails.details.scm.pullRequest.head.ref,
+        });
+        scmDetails.push({
+          title: "Head SHA",
+          value: taskDetails.details.scm.pullRequest.head.sha,
+        });
+        scmDetails.push({
+          title: "Base",
+          value: taskDetails.details.scm.pullRequest.base.ref,
+        });
+        scmDetails.push({
+          title: "Base SHA",
+          value: taskDetails.details.scm.pullRequest.base.sha,
+        });
+      } else if (taskDetails.details.scm.branch != null) {
+        scmDetails.push({
+          title: "Branch",
+          value: taskDetails.details.scm.branch.name,
+        }),
+          scmDetails.push({
+            title: "SHA",
+            value: taskDetails.details.scm.branch.sha,
+          });
+        scmDetails.push({
+          title: "Commit",
+          value: taskDetails.details.scm.commitMessage,
+        });
+      } else if (taskDetails.details.scm.release != null) {
+        scmDetails.push({
+          title: "Release",
+          value: taskDetails.details.scm.release.name,
+        });
+        scmDetails.push({
+          title: "Tag",
+          value: taskDetails.details.scm.release.tag,
+        });
+        scmDetails.push({
+          title: "SHA",
+          value: taskDetails.details.scm.release.sha,
+        });
+      }
     }
     const buildRows = await dependencies.db.fetchBuild(task.build_id);
     const build = buildRows.rows[0];
-    const artifacts =
-      taskDetails.details.result != null &&
-      taskDetails.details.result.artifacts != null
-        ? taskDetails.details.result.artifacts
-        : [];
-
-    const scmDetails = [];
-    if (taskDetails.details.scm.pullRequest != null) {
-      scmDetails.push({
-        title: "PR Number",
-        value: taskDetails.details.scm.pullRequest.number,
-      });
-      scmDetails.push({
-        title: "Head",
-        value: taskDetails.details.scm.pullRequest.head.ref,
-      });
-      scmDetails.push({
-        title: "Head SHA",
-        value: taskDetails.details.scm.pullRequest.head.sha,
-      });
-      scmDetails.push({
-        title: "Base",
-        value: taskDetails.details.scm.pullRequest.base.ref,
-      });
-      scmDetails.push({
-        title: "Base SHA",
-        value: taskDetails.details.scm.pullRequest.base.sha,
-      });
-    } else if (taskDetails.details.scm.branch != null) {
-      scmDetails.push({
-        title: "Branch",
-        value: taskDetails.details.scm.branch.name,
-      }),
-        scmDetails.push({
-          title: "SHA",
-          value: taskDetails.details.scm.branch.sha,
-        });
-      scmDetails.push({
-        title: "Commit",
-        value: taskDetails.details.scm.commitMessage,
-      });
-    } else if (taskDetails.details.scm.release != null) {
-      scmDetails.push({
-        title: "Release",
-        value: taskDetails.details.scm.release.name,
-      });
-      scmDetails.push({
-        title: "Tag",
-        value: taskDetails.details.scm.release.tag,
-      });
-      scmDetails.push({
-        title: "SHA",
-        value: taskDetails.details.scm.release.sha,
-      });
-    }
 
     res.render(dependencies.viewsPath + "history/buildTaskDetails", {
       owners: owners,

--- a/controllers/history/taskDetails.js
+++ b/controllers/history/taskDetails.js
@@ -14,86 +14,94 @@ function path() {
 async function handle(req, res, dependencies, owners) {
   const taskRows = await dependencies.db.fetchTask(req.query.taskID);
   const task = taskRows.rows[0];
-  const detailsRows = await dependencies.db.fetchTaskDetails(req.query.taskID);
-  const taskDetails = detailsRows.rows[0];
-  const configValues = [];
-  if (req.validAdminSession == true) {
-    Object.keys(
-      taskDetails.details.config != null ? taskDetails.details.config : {}
-    ).forEach(function (key) {
-      configValues.push({
-        key: key,
-        value: taskDetails.details.config[key].value,
-        source: taskDetails.details.config[key].source,
-      });
-    });
-  }
   const buildRows = await dependencies.db.fetchBuild(task.build_id);
   const build = buildRows.rows[0];
-  const summary =
-    taskDetails.details.result != null &&
-    taskDetails.details.result.summary != null
-      ? taskDetails.details.result.summary
-      : "";
-  const text =
-    taskDetails.details.result != null &&
-    taskDetails.details.result.text != null
-      ? taskDetails.details.result.text
-      : "";
-  const artifacts =
-    taskDetails.details.result != null &&
-    taskDetails.details.result.artifacts != null
-      ? taskDetails.details.result.artifacts
-      : [];
 
+  const configValues = [];
+  let summary = "";
+  let text = "";
+  let artifacts = [];
+  let taskDetails = { details: {} };
   const scmDetails = [];
-  if (taskDetails.details.scm.pullRequest != null) {
-    scmDetails.push({
-      title: "PR Number",
-      value: taskDetails.details.scm.pullRequest.number,
-    });
-    scmDetails.push({
-      title: "Head",
-      value: taskDetails.details.scm.pullRequest.head.ref,
-    });
-    scmDetails.push({
-      title: "Head SHA",
-      value: taskDetails.details.scm.pullRequest.head.sha,
-    });
-    scmDetails.push({
-      title: "Base",
-      value: taskDetails.details.scm.pullRequest.base.ref,
-    });
-    scmDetails.push({
-      title: "Base SHA",
-      value: taskDetails.details.scm.pullRequest.base.sha,
-    });
-  } else if (taskDetails.details.scm.branch != null) {
-    scmDetails.push({
-      title: "Branch",
-      value: taskDetails.details.scm.branch.name,
-    }),
+
+  const detailsRows = await dependencies.db.fetchTaskDetails(req.query.taskID);
+  if (detailsRows.rows.length > 0) {
+    taskDetails = detailsRows.rows[0];
+    if (req.validAdminSession == true) {
+      Object.keys(
+        taskDetails.details.config != null ? taskDetails.details.config : {}
+      ).forEach(function (key) {
+        configValues.push({
+          key: key,
+          value: taskDetails.details.config[key].value,
+          source: taskDetails.details.config[key].source,
+        });
+      });
+    }
+    summary =
+      taskDetails.details.result != null &&
+      taskDetails.details.result.summary != null
+        ? taskDetails.details.result.summary
+        : "";
+    text =
+      taskDetails.details.result != null &&
+      taskDetails.details.result.text != null
+        ? taskDetails.details.result.text
+        : "";
+    artifacts =
+      taskDetails.details.result != null &&
+      taskDetails.details.result.artifacts != null
+        ? taskDetails.details.result.artifacts
+        : [];
+
+    if (taskDetails.details.scm.pullRequest != null) {
+      scmDetails.push({
+        title: "PR Number",
+        value: taskDetails.details.scm.pullRequest.number,
+      });
+      scmDetails.push({
+        title: "Head",
+        value: taskDetails.details.scm.pullRequest.head.ref,
+      });
+      scmDetails.push({
+        title: "Head SHA",
+        value: taskDetails.details.scm.pullRequest.head.sha,
+      });
+      scmDetails.push({
+        title: "Base",
+        value: taskDetails.details.scm.pullRequest.base.ref,
+      });
+      scmDetails.push({
+        title: "Base SHA",
+        value: taskDetails.details.scm.pullRequest.base.sha,
+      });
+    } else if (taskDetails.details.scm.branch != null) {
+      scmDetails.push({
+        title: "Branch",
+        value: taskDetails.details.scm.branch.name,
+      }),
+        scmDetails.push({
+          title: "SHA",
+          value: taskDetails.details.scm.branch.sha,
+        });
+      scmDetails.push({
+        title: "Commit",
+        value: taskDetails.details.scm.commitMessage,
+      });
+    } else if (taskDetails.details.scm.release != null) {
+      scmDetails.push({
+        title: "Release",
+        value: taskDetails.details.scm.release.name,
+      });
+      scmDetails.push({
+        title: "Tag",
+        value: taskDetails.details.scm.release.tag,
+      });
       scmDetails.push({
         title: "SHA",
-        value: taskDetails.details.scm.branch.sha,
+        value: taskDetails.details.scm.release.sha,
       });
-    scmDetails.push({
-      title: "Commit",
-      value: taskDetails.details.scm.commitMessage,
-    });
-  } else if (taskDetails.details.scm.release != null) {
-    scmDetails.push({
-      title: "Release",
-      value: taskDetails.details.scm.release.name,
-    });
-    scmDetails.push({
-      title: "Tag",
-      value: taskDetails.details.scm.release.tag,
-    });
-    scmDetails.push({
-      title: "SHA",
-      value: taskDetails.details.scm.release.sha,
-    });
+    }
   }
 
   res.render(dependencies.viewsPath + "history/taskDetails", {

--- a/controllers/repositories/taskDetails.js
+++ b/controllers/repositories/taskDetails.js
@@ -14,86 +14,93 @@ function path() {
 async function handle(req, res, dependencies, owners) {
   const taskRows = await dependencies.db.fetchTask(req.query.taskID);
   const task = taskRows.rows[0];
-  const detailsRows = await dependencies.db.fetchTaskDetails(req.query.taskID);
-  const taskDetails = detailsRows.rows[0];
-  const configValues = [];
-  if (req.validAdminSession == true) {
-    Object.keys(
-      taskDetails.details.config != null ? taskDetails.details.config : {}
-    ).forEach(function (key) {
-      configValues.push({
-        key: key,
-        value: taskDetails.details.config[key].value,
-        source: taskDetails.details.config[key].source,
-      });
-    });
-  }
   const buildRows = await dependencies.db.fetchBuild(task.build_id);
   const build = buildRows.rows[0];
-  const summary =
-    taskDetails.details.result != null &&
-    taskDetails.details.result.summary != null
-      ? taskDetails.details.result.summary
-      : "";
-  const text =
-    taskDetails.details.result != null &&
-    taskDetails.details.result.text != null
-      ? taskDetails.details.result.text
-      : "";
-  const artifacts =
-    taskDetails.details.result != null &&
-    taskDetails.details.result.artifacts != null
-      ? taskDetails.details.result.artifacts
-      : [];
 
-  const scmDetails = [];
-  if (taskDetails.details.scm.pullRequest != null) {
-    scmDetails.push({
-      title: "PR Number",
-      value: taskDetails.details.scm.pullRequest.number,
-    });
-    scmDetails.push({
-      title: "Head",
-      value: taskDetails.details.scm.pullRequest.head.ref,
-    });
-    scmDetails.push({
-      title: "Head SHA",
-      value: taskDetails.details.scm.pullRequest.head.sha,
-    });
-    scmDetails.push({
-      title: "Base",
-      value: taskDetails.details.scm.pullRequest.base.ref,
-    });
-    scmDetails.push({
-      title: "Base SHA",
-      value: taskDetails.details.scm.pullRequest.base.sha,
-    });
-  } else if (taskDetails.details.scm.branch != null) {
-    scmDetails.push({
-      title: "Branch",
-      value: taskDetails.details.scm.branch.name,
-    }),
+  const detailsRows = await dependencies.db.fetchTaskDetails(req.query.taskID);
+  let taskDetails = { details: {} };
+  let configValues = [];
+  let scmDetails = [];
+  let summary = "";
+  let text = "";
+  let artifacts = [];
+  if (detailsRows.rows.length > 0) {
+    taskDetails = detailsRows.rows[0];
+    if (req.validAdminSession == true) {
+      Object.keys(
+        taskDetails.details.config != null ? taskDetails.details.config : {}
+      ).forEach(function (key) {
+        configValues.push({
+          key: key,
+          value: taskDetails.details.config[key].value,
+          source: taskDetails.details.config[key].source,
+        });
+      });
+    }
+    summary =
+      taskDetails.details.result != null &&
+      taskDetails.details.result.summary != null
+        ? taskDetails.details.result.summary
+        : "";
+    text =
+      taskDetails.details.result != null &&
+      taskDetails.details.result.text != null
+        ? taskDetails.details.result.text
+        : "";
+    artifacts =
+      taskDetails.details.result != null &&
+      taskDetails.details.result.artifacts != null
+        ? taskDetails.details.result.artifacts
+        : [];
+
+    if (taskDetails.details.scm.pullRequest != null) {
+      scmDetails.push({
+        title: "PR Number",
+        value: taskDetails.details.scm.pullRequest.number,
+      });
+      scmDetails.push({
+        title: "Head",
+        value: taskDetails.details.scm.pullRequest.head.ref,
+      });
+      scmDetails.push({
+        title: "Head SHA",
+        value: taskDetails.details.scm.pullRequest.head.sha,
+      });
+      scmDetails.push({
+        title: "Base",
+        value: taskDetails.details.scm.pullRequest.base.ref,
+      });
+      scmDetails.push({
+        title: "Base SHA",
+        value: taskDetails.details.scm.pullRequest.base.sha,
+      });
+    } else if (taskDetails.details.scm.branch != null) {
+      scmDetails.push({
+        title: "Branch",
+        value: taskDetails.details.scm.branch.name,
+      }),
+        scmDetails.push({
+          title: "SHA",
+          value: taskDetails.details.scm.branch.sha,
+        });
+      scmDetails.push({
+        title: "Commit",
+        value: taskDetails.details.scm.commitMessage,
+      });
+    } else if (taskDetails.details.scm.release != null) {
+      scmDetails.push({
+        title: "Release",
+        value: taskDetails.details.scm.release.name,
+      });
+      scmDetails.push({
+        title: "Tag",
+        value: taskDetails.details.scm.release.tag,
+      });
       scmDetails.push({
         title: "SHA",
-        value: taskDetails.details.scm.branch.sha,
+        value: taskDetails.details.scm.release.sha,
       });
-    scmDetails.push({
-      title: "Commit",
-      value: taskDetails.details.scm.commitMessage,
-    });
-  } else if (taskDetails.details.scm.release != null) {
-    scmDetails.push({
-      title: "Release",
-      value: taskDetails.details.scm.release.name,
-    });
-    scmDetails.push({
-      title: "Tag",
-      value: taskDetails.details.scm.release.tag,
-    });
-    scmDetails.push({
-      title: "SHA",
-      value: taskDetails.details.scm.release.sha,
-    });
+    }
   }
 
   res.render(dependencies.viewsPath + "repositories/taskDetails", {

--- a/lib/db.js
+++ b/lib/db.js
@@ -40,16 +40,13 @@ async function start(conf, logger) {
 
   pool.on("connect", (client) => {
     systemLogger.info("Database Connected");
-    if (createdTables === false) {
-      createTables(client);
-      createdTables = true;
-      updateTables(client);
-    }
   });
 
   pool.on("error", (error, client) => {
     systemLogger.error("Database error: " + error);
   });
+
+  createTables(pool);
 }
 
 /**
@@ -912,6 +909,17 @@ async function removeBuild(build_id) {
   await execute("removeBuildDeleteBuild", deleteBuild, [build_id]);
 }
 
+async function archiveBuild(build_id) {
+  let query = "UPDATE stampede.builds set archived = 'Y' WHERE build_id = $1";
+  await execute("archiveBuild", query, [build_id]);
+}
+
+async function removeTaskDetails(build_id) {
+  let deleteTaskDetails =
+    "DELETE from stampede.taskDetails WHERE task_id in (select task_id from stampede.tasks where build_id = $1)";
+  await execute("removeTaskDetails", deleteTaskDetails, [build_id]);
+}
+
 async function buildsForRetention(source, keepDays) {
   let keepDate = moment().subtract(keepDays, "days").toDate();
   let query =
@@ -925,16 +933,16 @@ async function buildsForRetention(source, keepDays) {
 async function createTables(client) {
   systemLogger.info("Creating stampede database schema if needed");
 
-  client.query("CREATE SCHEMA IF NOT EXISTS stampede;");
+  await client.query("CREATE SCHEMA IF NOT EXISTS stampede;");
 
-  client.query(
+  await client.query(
     "CREATE TABLE IF NOT EXISTS stampede.repositories \
     (owner varchar, \
       repository varchar, \
     PRIMARY KEY (owner, repository));"
   );
 
-  client.query(
+  await client.query(
     "CREATE TABLE IF NOT EXISTS stampede.builds \
     (build_id varchar, \
       owner varchar, \
@@ -945,10 +953,11 @@ async function createTables(client) {
       started_at timestamptz, \
       completed_at timestamptz, \
       source varchar, \
+      archived varchar, \
     PRIMARY KEY (build_id));"
   );
 
-  client.query(
+  await client.query(
     "CREATE TABLE IF NOT EXISTS stampede.tasks \
     (task_id varchar, \
       build_id varchar, \
@@ -963,19 +972,19 @@ async function createTables(client) {
       PRIMARY KEY (task_id));"
   );
 
-  client.query(
+  await client.query(
     "CREATE TABLE IF NOT EXISTS stampede.taskDetails \
     (task_id varchar, \
       details jsonb, \
       PRIMARY KEY (task_id));"
   );
 
-  client.query(
+  await client.query(
     "CREATE TABLE IF NOT EXISTS stampede.version \
     (version int);"
   );
-  client.query("DELETE FROM stampede.version;");
-  client.query("INSERT into stampede.version (version) VALUES (2);");
+
+  await updateTables(client);
 }
 
 /**
@@ -984,28 +993,48 @@ async function createTables(client) {
  */
 async function updateTables(client) {
   systemLogger.info("Checking for stampede database schema updates");
+  let currentVersion = 0;
   const version = await execute(
     "selectVersion",
     "SELECT * FROM stampede.version",
     []
   );
-  const currentVersion = version.rows[0].version;
-  systemLogger.info("Current schema version: " + currentVersion);
-  if (currentVersion === 1) {
-    systemLogger.info("Updating stampede database schema to version 2");
-    await client.query(
-      "ALTER TABLE stampede.builds ADD COLUMN source varchar;"
+  if (version.rows.length == 0) {
+    await client.query("INSERT into stampede.version (version) VALUES (3);");
+    return;
+  }
+  currentVersion = version.rows[0].version;
+
+  while (currentVersion != 3) {
+    systemLogger.info("Current schema version: " + currentVersion);
+    if (currentVersion === 1) {
+      systemLogger.info("Updating stampede database schema to version 2");
+      await client.query(
+        "ALTER TABLE stampede.builds ADD COLUMN source varchar;"
+      );
+      await client.query(
+        "CREATE INDEX index_owner ON stampede.repositories (owner)"
+      );
+      await client.query(
+        "CREATE INDEX index_ownrepostatus ON stampede.builds (owner, repository, status)"
+      );
+      await client.query(
+        "CREATE INDEX index_ownreposource ON stampede.builds (owner, repository, source)"
+      );
+      await client.query("UPDATE stampede.version SET version = 2");
+    } else if (currentVersion === 2) {
+      systemLogger.info("Updating stampede database schema to version 3");
+      await client.query(
+        "ALTER TABLE stampede.builds ADD COLUMN archived varchar;"
+      );
+      await client.query("UPDATE stampede.version SET version = 3");
+    }
+    const version = await execute(
+      "selectVersion",
+      "SELECT * FROM stampede.version",
+      []
     );
-    await client.query("UPDATE stampede.version SET version = 2");
-    await client.query(
-      "CREATE INDEX index_owner ON stampede.repositories (owner)"
-    );
-    await client.query(
-      "CREATE INDEX index_ownrepostatus ON stampede.builds (owner, repository, status)"
-    );
-    await client.query(
-      "CREATE INDEX index_ownreposource ON stampede.builds (owner, repository, source)"
-    );
+    currentVersion = version.rows[0].version;
   }
 }
 
@@ -1059,3 +1088,5 @@ module.exports.removeRepository = removeRepository;
 module.exports.mostRecentBuild = mostRecentBuild;
 module.exports.removeBuild = removeBuild;
 module.exports.buildsForRetention = buildsForRetention;
+module.exports.archiveBuild = archiveBuild;
+module.exports.removeTaskDetails = removeTaskDetails;

--- a/lib/retentionHandler.js
+++ b/lib/retentionHandler.js
@@ -40,11 +40,11 @@ async function deleteBuilds(builds, dependencies) {
 }
 
 async function deleteBuild(build, dependencies) {
+  dependencies.logger.info("DELETING BUILD: " + build.build_id);
   const artifacts = await fetchBuildArtifacts(build, dependencies);
   await queueArtifactCleanupTasks(artifacts, dependencies);
-
-  dependencies.logger.info("DELETING BUILD: " + build.build_id);
-  await dependencies.db.removeBuild(build.build_id);
+  await dependencies.db.removeTaskDetails(build.build_id);
+  await dependencies.db.archiveBuild(build.build_id);
 }
 
 async function fetchBuildArtifacts(build, dependencies) {

--- a/views/history/buildTaskDetails.pug
+++ b/views/history/buildTaskDetails.pug
@@ -33,7 +33,7 @@ block content
                 +tableRow()
                   +tableCell(detail.title)
                   +tableCell(detail.value)
-              if isAdmin == true
+              if isAdmin == true && configValues.length > 0
                 +tableRow()
                   +tableCellButton('Requeue', '/history/requeueTask?taskID=' + task.task_id)
                   +tableCell('')

--- a/views/history/taskDetails.pug
+++ b/views/history/taskDetails.pug
@@ -34,7 +34,7 @@ block content
                 +tableRow()
                   +tableCell(detail.title)
                   +tableCell(detail.value)
-              if isAdmin == true
+              if isAdmin == true && configValues.length > 0
                 +tableRow()
                   +tableCellButton('Requeue', '/history/requeueTask?taskID=' + task.task_id)
                   +tableCell('')

--- a/views/repositories/taskDetails.pug
+++ b/views/repositories/taskDetails.pug
@@ -31,7 +31,7 @@ block content
                 +tableRow()
                   +tableCell(detail.title)
                   +tableCell(detail.value)
-              if isAdmin == true
+              if isAdmin == true && configValues.length > 0
                 +tableRow()
                   +tableCellButton('Requeue', '/repositories/requeueTask?taskID=' + task.task_id)
                   +tableCell('')


### PR DESCRIPTION
This PR changes the retention handler to mark a build as archived instead of deleting it. We want to keep the builds around for reporting purposes, but we do want to cleanup the details. So this change also deletes the TaskDetails for any tasks in the archived build. It keeps the execution of the cleanup artifact task, although this might change in a subsequent PR. The last changes are to the task details screens to allow them to display a task without a task details record in the database.

closes #449 
