### PR TITLE
✨Added API for fetching an archived build with task details

### DIFF
--- a/api/history/archivedBuildWithTaskDetails.js
+++ b/api/history/archivedBuildWithTaskDetails.js
@@ -1,0 +1,26 @@
+"use strict";
+
+/**
+ * The url path this handler will serve
+ */
+function path() {
+  return "/api/history/archivedBuildWithTaskDetails";
+}
+
+/**
+ * handle
+ * @param {*} req
+ * @param {*} res
+ * @param {*} dependencies
+ */
+async function handle(req, res, dependencies) {
+  const build = await dependencies.db.archivedBuildWithTaskDetails();
+  let found = {};
+  if (build.rows.length > 0) {
+    found = build.rows[0];
+  }
+  res.send(found);
+}
+
+module.exports.path = path;
+module.exports.handle = handle;

--- a/api/history/archivedBuildWithTaskDetails.js
+++ b/api/history/archivedBuildWithTaskDetails.js
@@ -18,6 +18,17 @@ async function handle(req, res, dependencies) {
   let found = {};
   if (build.rows.length > 0) {
     found = build.rows[0];
+    const buildTasks = await dependencies.db.fetchBuildTasks(found.build_id);
+    const tasks = [];
+    for (let index = 0; index < buildTasks.rows.length; index++) {
+      const task = buildTasks.rows[index];
+      const detailsRows = await dependencies.db.fetchTaskDetails(task.task_id);
+      if (detailsRows.rows.length > 0) {
+        task.details = detailsRows.rows[0].details;
+      }
+      tasks.push(task);
+    }
+    found.tasks = tasks;
   }
   res.send(found);
 }

--- a/lib/db.js
+++ b/lib/db.js
@@ -927,6 +927,15 @@ async function buildsForRetention(source, keepDays) {
   return await execute("buildsForRetention", query, [source, keepDate]);
 }
 
+async function archivedBuildWithTaskDetails() {
+  let query =
+    "SELECT * from stampede.builds WHERE \
+    archived = 'Y' AND \
+    build_id in (SELECT build_id FROM stampede.tasks WHERE task_id in (SELECT task_id from stampede.taskDetails)) \
+    LIMIT 1";
+  return await execute("archivedBuildWithTaskDetails", query, []);
+}
+
 /**
  * createTables
  */
@@ -1090,3 +1099,4 @@ module.exports.removeBuild = removeBuild;
 module.exports.buildsForRetention = buildsForRetention;
 module.exports.archiveBuild = archiveBuild;
 module.exports.removeTaskDetails = removeTaskDetails;
+module.exports.archivedBuildWithTaskDetails = archivedBuildWithTaskDetails;


### PR DESCRIPTION
This PR adds an API endpoint so that clients can fetch an archived build that has task details. These types of builds may require additional cleanup, for example when artifacts need to be cleaned up from an external system.

closes #456 
