### PR TITLE
✨ Added API for removing all task details for a build

### DIFF
--- a/api/history/removeTaskDetails.js
+++ b/api/history/removeTaskDetails.js
@@ -1,0 +1,28 @@
+"use strict";
+
+/**
+ * The url path this handler will serve
+ */
+function path() {
+  return "/api/history/removeTaskDetails";
+}
+
+function method() {
+  return "delete";
+}
+
+/**
+ * handle
+ * @param {*} req
+ * @param {*} res
+ * @param {*} dependencies
+ */
+async function handle(req, res, dependencies) {
+  const buildID = req.query.buildID;
+  await dependencies.db.removeTaskDetails(buildID);
+  res.send({ status: "OK" });
+}
+
+module.exports.path = path;
+module.exports.handle = handle;
+module.exports.method = method;

--- a/lib/api.js
+++ b/lib/api.js
@@ -29,6 +29,10 @@ function router(dependencies) {
           basicRouter.post(path, function (req, res) {
             handler.handle(req, res, dependencies);
           });
+        } else if (method === "delete") {
+          basicRouter.delete(path, function (req, res) {
+            handler.handle(req, res, dependencies);
+          });
         }
       }
     });


### PR DESCRIPTION
This PR adds an API for removing all task details for a build. Because task details take up some space in the database, removing them can save space. Also the presence of task details represents a build that might need archiving.

closes #457 