### PR TITLE
✨ Remove release duplicates on the repository details screen

### DIFF
--- a/controllers/repositories/repositoryDetails.js
+++ b/controllers/repositories/repositoryDetails.js
@@ -69,6 +69,12 @@ async function handle(req, res, dependencies, owners) {
     repository,
     "release"
   );
+  const releases = [];
+  for (let index = 0; index < releaseBuilds.rows.length; index++) {
+    if (!releases.includes(releaseBuilds.rows[index].build_key)) {
+      releases.push(releaseBuilds.rows[index].build_key);
+    }
+  }
 
   // Get the pull request list
   const prBuilds = await dependencies.db.fetchBuildKeys(
@@ -85,7 +91,7 @@ async function handle(req, res, dependencies, owners) {
     activeBuilds: activeBuilds.rows,
     repositoryBuilds: sortedBuilds,
     branchBuilds: branchBuilds.rows,
-    releaseBuilds: releaseBuilds.rows,
+    releases: releases,
     prBuilds: prBuilds.rows,
     prettyMilliseconds: (ms) => (ms != null ? prettyMilliseconds(ms) : ""),
   });

--- a/views/repositories/repositoryDetails.pug
+++ b/views/repositories/repositoryDetails.pug
@@ -70,10 +70,10 @@ block content
             table(class="table-auto w-full")
                 thead
                   +tableHeader('Release')
-                each build, i in releaseBuilds
+                each release, i in releases
                   tbody
-                    +tableRow(`/repositories/repositorySourceDetails?owner=` + owner + `&repository=` + repository + `&build_key=` + build.build_key)
-                      +tableUnderlinedCell(build.build_key, "underline")
+                    +tableRow(`/repositories/repositorySourceDetails?owner=` + owner + `&repository=` + repository + `&build_key=` + release)
+                      +tableUnderlinedCell(release, "underline")
 
 
     div(class="w-full p-3")


### PR DESCRIPTION
This PR removes the duplicates that can show up under Releases on the Repository Details screen.

closes #463 