### PR TITLE
♻️ Increased date range on repository build details screen

### DIFF
--- a/controllers/repositories/repositoryBuildDetails.js
+++ b/controllers/repositories/repositoryBuildDetails.js
@@ -48,7 +48,7 @@ async function handle(req, res, dependencies, owners) {
   }
 
   const recentBuilds = await dependencies.db.recentBuilds(
-    "Last 7 Days",
+    "All",
     build,
     owner + "/" + repository
   );


### PR DESCRIPTION
This PR increases the date range on the repository build details screen. Now it will show the last most recent builds, making it easier to find when the last ones were executed.

closes #468 