### PR TITLE
♻️ Repository builds now showing non-archived builds

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -771,14 +771,16 @@ async function fetchBuildKeys(owner, repository, source) {
       "SELECT DISTINCT build_key from stampede.builds WHERE \
     owner = $1 AND \
     repository = $2 AND \
-    source = $3 \
+    source = $3 AND \
+    archived is null \
     ORDER BY build_key";
   } else if (source === "pull-request") {
     query =
       "SELECT DISTINCT build_key from stampede.builds WHERE \
     owner = $1 AND \
     repository = $2 AND \
-    source = $3 \
+    source = $3 AND \
+    archived is null \
     ORDER BY build_key DESC \
     LIMIT 50";
   } else if (source === "release") {
@@ -786,7 +788,8 @@ async function fetchBuildKeys(owner, repository, source) {
       "SELECT build_key FROM stampede.builds \
         WHERE owner = $1 AND \
         repository = $2 AND \
-        source = $3 \
+        source = $3 AND \
+        archived is null \
         ORDER BY started_at DESC \
         LIMIT 10";
   }


### PR DESCRIPTION
This PR changes the repository details screen to limit the builds shown to ones that aren't archived. This keeps the list focused on the recent builds only.

closes #471 
