### PR TITLE
🐛 Fixed details url in github check

### DIFF
--- a/scm/github.js
+++ b/scm/github.js
@@ -256,6 +256,8 @@ async function createCheckRun(
       status: "queued",
       external_id: external_id,
       started_at: started_at,
+      details_url:
+        serverConf.webURL + "/history/buildTaskDetails?taskID=" + external_id,
     })
     .catch((error) => {
       systemLogger.error("Error creating check run: " + error);


### PR DESCRIPTION
This PR sets the details url for GitHub checks with a link to the task details for the checks task. Without the details url, GitHub will just take the user to the GitHub app root URL.

closes #415 