### PR TITLE
💄 Show task summary stats by status

### DIFF
--- a/controllers/history/taskSummary.js
+++ b/controllers/history/taskSummary.js
@@ -1,3 +1,5 @@
+const prettyMilliseconds = require("pretty-ms");
+
 /**
  * path this handler will serve
  */
@@ -51,13 +53,27 @@ async function handle(req, res, dependencies, owners) {
     const taskData = [];
     const taskColor = [];
     const summary = {
-      total: 0,
-      success: 0,
-      failure: 0,
-      totalDuration: 0,
-      avgDuration: 0,
-      minDuration: 999999,
-      maxDuration: 0,
+      total: {
+        count: 0,
+        totalDuration: 0,
+        avgDuration: 0,
+        minDuration: 999999,
+        maxDuration: 0,
+      },
+      success: {
+        count: 0,
+        totalDuration: 0,
+        avgDuration: 0,
+        minDuration: 999999,
+        maxDuration: 0,
+      },
+      failure: {
+        count: 0,
+        totalDuration: 0,
+        avgDuration: 0,
+        minDuration: 999999,
+        maxDuration: 0,
+      },
     };
 
     for (let tindex = 0; tindex < tasks.rows.length; tindex++) {
@@ -67,30 +83,61 @@ async function handle(req, res, dependencies, owners) {
         tasks.rows[tindex].conclusion
       ) {
         taskLabels.push(tasks.rows[tindex].task_id);
-        if (tasks.rows[tindex].conclusion === "success") {
-          summary.success = summary.success + 1;
-          taskColor.push("rgba(0, 255, 0, 0.6)");
-        } else {
-          summary.failure = summary.failure + 1;
-          taskColor.push("rgba(255, 0, 0, 0.6)");
-        }
         const duration =
           (tasks.rows[tindex].finished_at - tasks.rows[tindex].started_at) /
           1000.0;
-        taskData.push(duration);
-        summary.total = summary.total + 1;
-        summary.totalDuration = summary.totalDuration + duration;
-        if (summary.minDuration > duration) {
-          summary.minDuration = duration;
+        if (tasks.rows[tindex].conclusion === "success") {
+          summary.success.count = summary.success.count + 1;
+          summary.success.totalDuration =
+            summary.success.totalDuration + duration;
+          if (summary.success.minDuration > duration) {
+            summary.success.minDuration = duration;
+          }
+          if (summary.success.maxDuration < duration) {
+            summary.success.maxDuration = duration;
+          }
+          taskColor.push("rgba(0, 255, 0, 0.6)");
+        } else {
+          summary.failure.count = summary.failure.count + 1;
+          summary.failure.totalDuration =
+            summary.failure.totalDuration + duration;
+          if (summary.failure.minDuration > duration) {
+            summary.failure.minDuration = duration;
+          }
+          if (summary.failure.maxDuration < duration) {
+            summary.failure.maxDuration = duration;
+          }
+          taskColor.push("rgba(255, 0, 0, 0.6)");
         }
-        if (summary.maxDuration < duration) {
-          summary.maxDuration = duration;
+        taskData.push(duration);
+        summary.total.count = summary.total.count + 1;
+        summary.total.totalDuration = summary.total.totalDuration + duration;
+        if (summary.total.minDuration > duration) {
+          summary.total.minDuration = duration;
+        }
+        if (summary.total.maxDuration < duration) {
+          summary.total.maxDuration = duration;
         }
       }
     }
 
-    if (summary.total > 0) {
-      summary.avgDuration = summary.totalDuration / summary.total;
+    if (summary.total.count > 0) {
+      summary.total.avgDuration =
+        summary.total.totalDuration / summary.total.count;
+    } else {
+      summary.total.minDuration = 0;
+    }
+    if (summary.success.count > 0) {
+      summary.success.avgDuration =
+        summary.success.totalDuration / summary.success.count;
+    } else {
+      summary.success.minDuration = 0;
+    }
+    if (summary.failure.count > 0) {
+      summary.failure.avgDuration =
+        summary.failure.totalDuration / summary.failure.count;
+    } else {
+      summary.failure.minDuration = 0;
     }
 
     let data = {
@@ -128,6 +175,7 @@ async function handle(req, res, dependencies, owners) {
     ],
     repositoryFilter: repositoryFilter,
     repositoryList: repositories,
+    prettyMilliseconds: (ms) => (ms != null ? prettyMilliseconds(ms) : ""),
   });
 }
 

--- a/views/history/taskSummary.pug
+++ b/views/history/taskSummary.pug
@@ -26,7 +26,7 @@ block content
     each graph, i in graphs
 
       +infoCard(graph.task)
-        if graph.summary.total > 0
+        if graph.summary.total.count > 0
           div(class="chart-container w-full")
             canvas(id=``+graph.task height="100")
               script.
@@ -55,22 +55,32 @@ block content
           table(class="table-auto w-full mt-4")
             tbody
               +tableRow()
-                +tableCell('# of Executions')
-                +tableCell(graph.summary.total)
-              +tableRow()
-                +tableCell('# Success')
-                +tableCell(graph.summary.success)
-              +tableRow()
-                +tableCell('# Failure')
-                +tableCell(graph.summary.failure)
+                +tableCell('Total # of Executions')
+                +tableCell(graph.summary.total.count)
+                +tableCell('Total # of Success')
+                +tableCell(graph.summary.success.count)
+                +tableCell('Total # of Failure')
+                +tableCell(graph.summary.failure.count)
               +tableRow()
                 +tableCell('Avg Duration (s)')
-                +tableCell(graph.summary.avgDuration)
+                +tableCell(prettyMilliseconds(graph.summary.total.avgDuration * 1000.0))
+                +tableCell('Avg Duration Success (s)')
+                +tableCell(prettyMilliseconds(graph.summary.success.avgDuration * 1000.0))
+                +tableCell('Avg Duration Failure (s)')
+                +tableCell(prettyMilliseconds(graph.summary.failure.avgDuration * 1000.0))
               +tableRow()
                 +tableCell('Min Duration (s)')
-                +tableCell(graph.summary.minDuration)
+                +tableCell(prettyMilliseconds(graph.summary.total.minDuration * 1000.0))
+                +tableCell('Min Duration Success (s)')
+                +tableCell(prettyMilliseconds(graph.summary.success.minDuration * 1000.0))
+                +tableCell('Min Duration Failure (s)')
+                +tableCell(prettyMilliseconds(graph.summary.failure.minDuration * 1000.0))
               +tableRow()
                 +tableCell('Max Duration (s)')
-                +tableCell(graph.summary.maxDuration)
+                +tableCell(prettyMilliseconds(graph.summary.total.maxDuration * 1000.0))
+                +tableCell('Max Duration Success (s)')
+                +tableCell(prettyMilliseconds(graph.summary.success.maxDuration * 1000.0))
+                +tableCell('Max Duration Failure (s)')
+                +tableCell(prettyMilliseconds(graph.summary.failure.maxDuration * 1000.0))
         else
           p No task executions found with this filter criteria


### PR DESCRIPTION
This PR updates the Task Summary report by breaking out the task stats by status. Now the success & failed executions are counted & summarized separately, along with the totals.

closes #484 