### PR TITLE
✨ Server now supports required task parameters

### DIFF
--- a/lib/task.js
+++ b/lib/task.js
@@ -3,6 +3,7 @@
 const taskDetail = require("./taskDetail");
 const notification = require("./notification");
 const taskQueue = require("./taskQueue");
+const taskUpdate = require("./taskUpdate");
 
 /**
  * startTasks
@@ -205,20 +206,15 @@ async function startTask(
   db,
   logger
 ) {
+  const taskID =
+    buildPath + "-" + buildNumber + "-" + task.id + "-" + taskNumber.toString();
+
   try {
     const isValid = await taskDetail.isValidTask(task.id, cache);
     if (isValid == false) {
       return;
     }
 
-    const taskID =
-      buildPath +
-      "-" +
-      buildNumber +
-      "-" +
-      task.id +
-      "-" +
-      taskNumber.toString();
     logger.verbose("starting task: " + taskID);
     const taskTitle = await taskDetail.taskTitle(task.id, task, cache);
     const taskConfig = await taskDetail.taskConfig(
@@ -268,12 +264,49 @@ async function startTask(
       },
     };
 
-    let queueName = await taskDetail.taskQueue(taskDetails.task.id, cache);
-    if (queueName != null) {
-      if (overrideTaskQueue != null) {
-        queueName = overrideTaskQueue;
+    // Ensure we have all the required parameters. If we are missing any then fail the task before
+    // we add it to a queue
+    let validParams = true;
+    Object.keys(taskConfig).forEach(function (key) {
+      if (taskConfig[key].source === "missing-required") {
+        validParams = false;
       }
-      logger.verbose("Creating task: " + taskID);
+    });
+
+    if (validParams == true) {
+      let queueName = await taskDetail.taskQueue(taskDetails.task.id, cache);
+      if (queueName != null) {
+        if (overrideTaskQueue != null) {
+          queueName = overrideTaskQueue;
+        }
+        logger.verbose("Creating task: " + taskID);
+        try {
+          await db.storeTaskStart(
+            taskDetails.taskID,
+            taskDetails.buildID,
+            taskDetails.task.id,
+            taskDetails.status,
+            taskDetails.stats.queuedAt
+          );
+          await db.storeTaskDetails(taskDetails.taskID, taskDetails);
+        } catch (e) {
+          logger.verbose("Error Storing task start details: " + e);
+        }
+        await notification.taskStarted(taskID, taskDetails);
+        taskDetails.taskQueue = queueName;
+        logger.verbose("Adding task to queue: " + queueName);
+        const queue = taskQueue.createTaskQueue("stampede-" + queueName);
+        await queue.add(taskDetails, {
+          removeOnComplete: true,
+          removeOnFail: true,
+        });
+        await queue.close();
+      } else {
+        logger.verbose("Unable to determine queue name");
+      }
+    } else {
+      logger.verbose("Task missing required parameters, failing the task");
+
       try {
         await db.storeTaskStart(
           taskDetails.taskID,
@@ -287,16 +320,24 @@ async function startTask(
         logger.verbose("Error Storing task start details: " + e);
       }
       await notification.taskStarted(taskID, taskDetails);
-      taskDetails.taskQueue = queueName;
-      logger.verbose("Adding task to queue: " + queueName);
-      const queue = taskQueue.createTaskQueue("stampede-" + queueName);
-      await queue.add(taskDetails, {
-        removeOnComplete: true,
-        removeOnFail: true,
-      });
-      await queue.close();
-    } else {
-      logger.verbose("Unable to determine queue name");
+
+      // Call taskUpdate immediately to get all the completion steps to function correctly
+      taskDetails.status = "in_progress";
+      taskDetails.stats.startedAt = new Date();
+      taskDetails.worker = {
+        node: "none",
+        version: "",
+        workerID: "none",
+      };
+      taskUpdate.handle(taskDetails, serverConf, cache, scm, db, logger);
+
+      taskDetails.status = "completed";
+      taskDetails.result = {
+        conclusion: "failure",
+        summary: "Missing required task parameters",
+      };
+      taskDetails.stats.finishedAt = new Date();
+      taskUpdate.handle(taskDetails, serverConf, cache, scm, db, logger);
     }
   } catch (e) {
     logger.error("Error starting task " + taskID + ": " + e);

--- a/lib/taskDetail.js
+++ b/lib/taskDetail.js
@@ -121,6 +121,13 @@ async function taskConfig(
     }
     if (value != null) {
       config[key] = { value: value, source: source };
+    } else {
+      if (
+        globalTasksConfig.config[index].required != null &&
+        globalTasksConfig.config[index].required == true
+      ) {
+        config[key] = { value: "", source: "missing-required" };
+      }
     }
   }
   return config;


### PR DESCRIPTION
This PR updates task validation to check for required parameters when a task starts. Required parameters can be defined at the task level by adding `required: true` to the task param. Required parameters must have a value or else the task will fail immediately without being sent to a worker. Values can come from any source such as defaults or overrides, or in the task request itself.

closes #108