### PR TITLE
✨Embedded API Explorer

### DIFF
--- a/api/admin/configDefaults.js
+++ b/api/admin/configDefaults.js
@@ -17,12 +17,30 @@ async function handle(req, res, dependencies) {
   const systemDefaults = await dependencies.cache.fetchSystemDefaults();
   let defaults = {};
   if (systemDefaults != null) {
-    Object.keys(systemDefaults.defaults).forEach(function(key) {
+    Object.keys(systemDefaults.defaults).forEach(function (key) {
       defaults[key] = systemDefaults.defaults[key].toString();
     });
   }
   res.send({ defaults: defaults });
 }
 
+/**
+ * The OpenAPI docs
+ */
+function docs() {
+  return {
+    get: {
+      summary: "admin-configDefaults",
+      parameters: [],
+      responses: {
+        200: {
+          description: "",
+        },
+      },
+    },
+  };
+}
+
 module.exports.path = path;
 module.exports.handle = handle;
+module.exports.docs = docs;

--- a/api/admin/configOverrides.js
+++ b/api/admin/configOverrides.js
@@ -17,12 +17,30 @@ async function handle(req, res, dependencies) {
   const systemOverrides = await dependencies.cache.fetchSystemOverrides();
   let overrides = {};
   if (systemOverrides != null) {
-    Object.keys(systemOverrides.overrides).forEach(function(key) {
+    Object.keys(systemOverrides.overrides).forEach(function (key) {
       overrides[key] = systemOverrides.overrides[key].toString();
     });
   }
   res.send({ overrides: overrides });
 }
 
+/**
+ * The OpenAPI docs
+ */
+function docs() {
+  return {
+    get: {
+      summary: "admin-configOverrides",
+      parameters: [],
+      responses: {
+        200: {
+          description: "",
+        },
+      },
+    },
+  };
+}
+
 module.exports.path = path;
 module.exports.handle = handle;
+module.exports.docs = docs;

--- a/api/admin/queues.js
+++ b/api/admin/queues.js
@@ -18,5 +18,23 @@ async function handle(req, res, dependencies) {
   res.send(queueList);
 }
 
+/**
+ * The OpenAPI docs
+ */
+function docs() {
+  return {
+    get: {
+      summary: "admin-queues",
+      parameters: [],
+      responses: {
+        200: {
+          description: "",
+        },
+      },
+    },
+  };
+}
+
 module.exports.path = path;
 module.exports.handle = handle;
+module.exports.docs = docs;

--- a/api/admin/tasks.js
+++ b/api/admin/tasks.js
@@ -23,11 +23,29 @@ async function handle(req, res, dependencies) {
     );
     tasks.push({
       id: sortedTasks[index],
-      config: taskDetails
+      config: taskDetails,
     });
   }
   res.send(tasks);
 }
 
+/**
+ * The OpenAPI docs
+ */
+function docs() {
+  return {
+    get: {
+      summary: "admin-tasks",
+      parameters: [],
+      responses: {
+        200: {
+          description: "",
+        },
+      },
+    },
+  };
+}
+
 module.exports.path = path;
 module.exports.handle = handle;
+module.exports.docs = docs;

--- a/api/buildDetails.js
+++ b/api/buildDetails.js
@@ -23,9 +23,35 @@ async function handle(req, res, dependencies) {
       buildDetails != null && buildDetails.rows.length > 0
         ? buildDetails.rows[0]
         : {},
-    tasks: tasks.rows
+    tasks: tasks.rows,
   });
+}
+
+/**
+ * The OpenAPI docs
+ */
+function docs() {
+  return {
+    get: {
+      summary: "buildDetails",
+      parameters: [
+        {
+          in: "query",
+          name: "buildID",
+          schema: {
+            type: "string",
+          },
+        },
+      ],
+      responses: {
+        200: {
+          description: "",
+        },
+      },
+    },
+  };
 }
 
 module.exports.path = path;
 module.exports.handle = handle;
+module.exports.docs = docs;

--- a/api/history/tasks.js
+++ b/api/history/tasks.js
@@ -55,5 +55,23 @@ async function handle(req, res, dependencies) {
   res.send(tasks.rows);
 }
 
+/**
+ * The OpenAPI docs
+ */
+function docs() {
+  return {
+    get: {
+      summary: "history-tasks",
+      parameters: [],
+      responses: {
+        200: {
+          description: "",
+        },
+      },
+    },
+  };
+}
+
 module.exports.path = path;
 module.exports.handle = handle;
+module.exports.docs = docs;

--- a/api/monitor/activeBuilds.js
+++ b/api/monitor/activeBuilds.js
@@ -32,5 +32,23 @@ async function handle(req, res, dependencies) {
   res.send(activeBuilds);
 }
 
+/**
+ * The OpenAPI docs
+ */
+function docs() {
+  return {
+    get: {
+      summary: "monitor-activeBuilds",
+      parameters: [],
+      responses: {
+        200: {
+          description: "",
+        },
+      },
+    },
+  };
+}
+
 module.exports.path = path;
 module.exports.handle = handle;
+module.exports.docs = docs;

--- a/api/monitor/activeTasks.js
+++ b/api/monitor/activeTasks.js
@@ -31,5 +31,23 @@ async function handle(req, res, dependencies) {
   res.send(tasks);
 }
 
+/**
+ * The OpenAPI docs
+ */
+function docs() {
+  return {
+    get: {
+      summary: "monitor-activeTasks",
+      parameters: [],
+      responses: {
+        200: {
+          description: "",
+        },
+      },
+    },
+  };
+}
+
 module.exports.path = path;
 module.exports.handle = handle;
+module.exports.docs = docs;

--- a/api/monitor/queueSummary.js
+++ b/api/monitor/queueSummary.js
@@ -36,5 +36,23 @@ async function handle(req, res, dependencies) {
   res.send(queues);
 }
 
+/**
+ * The OpenAPI docs
+ */
+function docs() {
+  return {
+    get: {
+      summary: "monitor-queueSummary",
+      parameters: [],
+      responses: {
+        200: {
+          description: "",
+        },
+      },
+    },
+  };
+}
+
 module.exports.path = path;
 module.exports.handle = handle;
+module.exports.docs = docs;

--- a/api/monitor/workerStatus.js
+++ b/api/monitor/workerStatus.js
@@ -18,5 +18,23 @@ async function handle(req, res, dependencies) {
   res.send(activeWorkers);
 }
 
+/**
+ * The OpenAPI docs
+ */
+function docs() {
+  return {
+    get: {
+      summary: "monitor-workerStatus",
+      parameters: [],
+      responses: {
+        200: {
+          description: "",
+        },
+      },
+    },
+  };
+}
+
 module.exports.path = path;
 module.exports.handle = handle;
+module.exports.docs = docs;

--- a/api/repositories.js
+++ b/api/repositories.js
@@ -18,5 +18,22 @@ async function handle(req, res, dependencies) {
   res.send(repositories != null ? repositories.rows : []);
 }
 
+/**
+ * The OpenAPI docs
+ */
+function docs() {
+  return {
+    get: {
+      summary: "repositories",
+      responses: {
+        200: {
+          description: "",
+        },
+      },
+    },
+  };
+}
+
 module.exports.path = path;
 module.exports.handle = handle;
+module.exports.docs = docs;

--- a/api/repository/recentBuilds.js
+++ b/api/repository/recentBuilds.js
@@ -39,5 +39,38 @@ async function handle(req, res, dependencies) {
   res.send(builds);
 }
 
+/**
+ * The OpenAPI docs
+ */
+function docs() {
+  return {
+    get: {
+      summary: "repository-recentBuilds",
+      parameters: [
+        {
+          in: "query",
+          name: "owner",
+          schema: {
+            type: "string",
+          },
+        },
+        {
+          in: "query",
+          name: "repository",
+          schema: {
+            type: "string",
+          },
+        },
+      ],
+      responses: {
+        200: {
+          description: "",
+        },
+      },
+    },
+  };
+}
+
 module.exports.path = path;
 module.exports.handle = handle;
+module.exports.docs = docs;

--- a/api/repository/repositoryBuilds.js
+++ b/api/repository/repositoryBuilds.js
@@ -92,7 +92,7 @@ async function handle(req, res, dependencies) {
 function docs() {
   return {
     get: {
-      summary: "repository-recentBuilds",
+      summary: "repository-repositoryBuilds",
       parameters: [
         {
           in: "query",

--- a/api/repository/repositoryBuilds.js
+++ b/api/repository/repositoryBuilds.js
@@ -86,5 +86,38 @@ async function handle(req, res, dependencies) {
   res.send(repositoryBuilds);
 }
 
+/**
+ * The OpenAPI docs
+ */
+function docs() {
+  return {
+    get: {
+      summary: "repository-recentBuilds",
+      parameters: [
+        {
+          in: "query",
+          name: "owner",
+          schema: {
+            type: "string",
+          },
+        },
+        {
+          in: "query",
+          name: "repository",
+          schema: {
+            type: "string",
+          },
+        },
+      ],
+      responses: {
+        200: {
+          description: "",
+        },
+      },
+    },
+  };
+}
+
 module.exports.path = path;
 module.exports.handle = handle;
+module.exports.docs = docs;

--- a/bin/stampede-server.js
+++ b/bin/stampede-server.js
@@ -70,6 +70,8 @@ const conf = require("rc")("stampede", {
   // Retention
   defaultBuildRetentionDays: 30,
   defaultReleaseBuildRetentionDays: 3000,
+  // API Docs
+  enableApiDocs: false,
 });
 
 // Configure winston logging

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,6 +1,7 @@
 "use strict";
 let express = require("express");
 const glob = require("glob");
+const swaggerUi = require("swagger-ui-express");
 
 /**
  * The router for the API handlers
@@ -8,6 +9,7 @@ const glob = require("glob");
  */
 function router(dependencies) {
   let basicRouter = express.Router();
+  let docs = {};
 
   // Find all the API handlers and add them to our Router
   glob
@@ -19,6 +21,11 @@ function router(dependencies) {
         let method = "get";
         if (handler.method != null) {
           method = handler.method();
+        }
+
+        if (handler.docs != null) {
+          let apidocs = handler.docs();
+          docs[path] = apidocs;
         }
         dependencies.logger.info("API [" + method + "] " + path);
         if (method === "get") {
@@ -36,6 +43,29 @@ function router(dependencies) {
         }
       }
     });
+
+  const swaggerDocument = {
+    openapi: "3.0.0",
+    info: {
+      title: "Stampede API",
+      description: "The Stampede REST API",
+      termsOfService: "",
+      license: {},
+    },
+    servers: [
+      {
+        url: dependencies.serverConfig.webURL,
+        description: "Stampede server",
+      },
+    ],
+    paths: docs,
+  };
+  console.dir(swaggerDocument);
+
+  if (dependencies.serverConfig.enableApiDocs == true) {
+    basicRouter.use("/api/api-docs", swaggerUi.serve);
+    basicRouter.get("/api/api-docs", swaggerUi.setup(swaggerDocument));
+  }
 
   return basicRouter;
 }

--- a/lib/api.js
+++ b/lib/api.js
@@ -65,6 +65,10 @@ function router(dependencies) {
   if (dependencies.serverConfig.enableApiDocs == true) {
     basicRouter.use("/api/api-docs", swaggerUi.serve);
     basicRouter.get("/api/api-docs", swaggerUi.setup(swaggerDocument));
+  } else {
+    basicRouter.get("/api/api-docs", function (req, res) {
+      res.send("API Docs not enabled");
+    });
   }
 
   return basicRouter;

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -1,6 +1,7 @@
 "use strict";
 const express = require("express");
 const glob = require("glob");
+const swaggerUi = require("swagger-ui-express");
 
 /**
  * router
@@ -33,6 +34,37 @@ function router(dependencies) {
         }
       }
     });
+
+  const swaggerDocument = {
+    openapi: "3.0.0",
+    info: {
+      title: "Stampede API",
+      description: "The Stampede REST API",
+      termsOfService: "",
+      license: {},
+    },
+    servers: [
+      {
+        url: dependencies.serverConfig.webURL,
+        description: "Stampede server",
+      },
+    ],
+    paths: {
+      "/api/repositories": {
+        get: {
+          summary: "repositories",
+          responses: {
+            200: {
+              description: "",
+            },
+          },
+        },
+      },
+    },
+  };
+
+  basicRouter.use("/admin/api-docs", swaggerUi.serve);
+  basicRouter.get("/admin/api-docs", swaggerUi.setup(swaggerDocument));
 
   return basicRouter;
 }

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -1,7 +1,6 @@
 "use strict";
 const express = require("express");
 const glob = require("glob");
-const swaggerUi = require("swagger-ui-express");
 
 /**
  * router
@@ -34,37 +33,6 @@ function router(dependencies) {
         }
       }
     });
-
-  const swaggerDocument = {
-    openapi: "3.0.0",
-    info: {
-      title: "Stampede API",
-      description: "The Stampede REST API",
-      termsOfService: "",
-      license: {},
-    },
-    servers: [
-      {
-        url: dependencies.serverConfig.webURL,
-        description: "Stampede server",
-      },
-    ],
-    paths: {
-      "/api/repositories": {
-        get: {
-          summary: "repositories",
-          responses: {
-            200: {
-              description: "",
-            },
-          },
-        },
-      },
-    },
-  };
-
-  basicRouter.use("/admin/api-docs", swaggerUi.serve);
-  basicRouter.get("/admin/api-docs", swaggerUi.setup(swaggerDocument));
 
   return basicRouter;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5933,6 +5933,19 @@
         "has-flag": "^3.0.0"
       }
     },
+    "swagger-ui-dist": {
+      "version": "3.32.5",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.32.5.tgz",
+      "integrity": "sha512-3SKHv8UVqsKKknivtACHbFDGcn297jkoZN2h6zAZ7b2yoaJNMaRadQpC3qFw3GobZTGzqHCgHph4ZH9NkaCjrQ=="
+    },
+    "swagger-ui-express": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.1.4.tgz",
+      "integrity": "sha512-Ea96ecpC+Iq9GUqkeD/LFR32xSs8gYqmTW1gXCuKg81c26WV6ZC2FsBSPVExQP6WkyUuz5HEiR0sEv/HCC343g==",
+      "requires": {
+        "swagger-ui-dist": "^3.18.1"
+      }
+    },
     "table": {
       "version": "5.4.6",
       "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "rc": "^1.2.8",
     "sanitize-filename": "^1.6.3",
     "stampede-cache": "^0.15.0",
+    "swagger-ui-express": "^4.1.4",
     "uuid": "^3.4.0",
     "winston": "^3.3.3",
     "ws": "^6.0.0"

--- a/views/components/sideBar.pug
+++ b/views/components/sideBar.pug
@@ -31,6 +31,7 @@ mixin sideBar(activeMenu, owners, isAdmin)
                         {title: 'System Config', href: '/admin/systemConfig'},
                         {title: 'Reports', href: '/admin/reports'},
                         {title: 'Info', href: '/admin/info'},
+                        {title: 'API Docs', href: '/api/api-docs'},
                         {title: 'Logout', href: '/admin/logout'}
                         ])
                 else


### PR DESCRIPTION
This PR enables the server to be configured with a live API explorer that you can access from the Web UI. The explorer can be accessed via the `/api/api-docs` route, and also from the `API Docs` menu item. This explorer is disabled by default and can be enabled with the `enableApiDocs` server configuration parameter.

closes #482 

<img width="1676" alt="Screen Shot 2020-08-30 at 4 27 08 PM" src="https://user-images.githubusercontent.com/140127/91668939-d7a86c80-eade-11ea-8fe1-43a3d91e76bb.png">