### PR TITLE
🐛 Remove lastExecuted if not available

### DIFF
--- a/api/repository/repositoryBuilds.js
+++ b/api/repository/repositoryBuilds.js
@@ -39,7 +39,6 @@ async function handle(req, res, dependencies) {
     } else {
       repositoryBuilds.push({
         build: currentRepositoryBuilds[index],
-        lastExecuted: "",
       });
     }
   }


### PR DESCRIPTION
This PR fixes the `lastExecuted` field in the repository builds API response. Instead of empty string it removes the element. 

closes #501 
