### PR TITLE
✨ Added source to build history filter

### DIFF
--- a/controllers/history/buildSummary.js
+++ b/controllers/history/buildSummary.js
@@ -24,6 +24,7 @@ async function handle(req, res, dependencies, owners) {
   const builds = await dependencies.db.recentBuilds(
     "Last 12 hours",
     "All",
+    "All",
     "All"
   );
   const recentBuilds = builds.rows;

--- a/controllers/history/builds.js
+++ b/controllers/history/builds.js
@@ -45,10 +45,24 @@ async function handle(req, res, dependencies, owners) {
     );
   }
 
+  let sourceFilter = "All";
+  if (req.query.source != null) {
+    sourceFilter = req.query.source;
+  }
+
+  const sources = [
+    "All",
+    "Pull Request",
+    "Branch",
+    "Release",
+    "Repository Build",
+  ];
+
   const builds = await dependencies.db.recentBuilds(
     timeFilter,
     buildKeyFilter,
-    repositoryFilter
+    repositoryFilter,
+    sourceFilter
   );
 
   res.render(dependencies.viewsPath + "history/builds", {
@@ -75,6 +89,8 @@ async function handle(req, res, dependencies, owners) {
     buildKeyList: buildKeyList,
     repositoryFilter: repositoryFilter,
     repositoryList: repositories,
+    sourceFilter: sourceFilter,
+    sourceList: sources,
   });
 }
 

--- a/controllers/repositories/repositoryBuildDetails.js
+++ b/controllers/repositories/repositoryBuildDetails.js
@@ -50,7 +50,8 @@ async function handle(req, res, dependencies, owners) {
   const recentBuilds = await dependencies.db.recentBuilds(
     "All",
     build,
-    owner + "/" + repository
+    owner + "/" + repository,
+    "All"
   );
 
   res.render(dependencies.viewsPath + "repositories/repositoryBuildDetails", {

--- a/controllers/repositories/repositorySourceDetails.js
+++ b/controllers/repositories/repositorySourceDetails.js
@@ -21,7 +21,8 @@ async function handle(req, res, dependencies, owners) {
   const recentBuilds = await dependencies.db.recentBuilds(
     "All",
     build_key,
-    owner + "/" + repository
+    owner + "/" + repository,
+    "All"
   );
 
   res.render(dependencies.viewsPath + "repositories/repositorySourceDetails", {

--- a/lib/db.js
+++ b/lib/db.js
@@ -183,11 +183,17 @@ async function activeBuilds(owner, repository) {
 
 /**
  * recentBuilds
- * @param {int} timeFilter
- * @param {int} buildKeyFilter
+ * @param {string} timeFilter
+ * @param {string} buildKeyFilter
  * @param {string} repositoryFilter
+ * @param {string} sourceFilter
  */
-async function recentBuilds(timeFilter, buildKeyFilter, repositoryFilter) {
+async function recentBuilds(
+  timeFilter,
+  buildKeyFilter,
+  repositoryFilter,
+  sourceFilter
+) {
   let fromDate = new Date();
   let toDate = new Date();
   if (timeFilter === "Last 8 hours") {
@@ -246,6 +252,21 @@ async function recentBuilds(timeFilter, buildKeyFilter, repositoryFilter) {
     query += " AND repository = $" + (queryParams.length + 2);
     queryParams.push(repositoryFilter.split("/")[0]);
     queryParams.push(repositoryFilter.split("/")[1]);
+  }
+  console.log("sourceFilter: " + sourceFilter);
+  if (sourceFilter != "All") {
+    query += " AND source = $" + (queryParams.length + 1);
+    if (sourceFilter === "Pull Request") {
+      queryParams.push("pull-request");
+    } else if (sourceFilter === "Branch") {
+      queryParams.push("branch-push");
+    } else if (sourceFilter === "Release") {
+      queryParams.push("release");
+    } else if (sourceFilter === "Repository Build") {
+      queryParams.push("repository-build");
+    } else {
+      queryParams.push(" ");
+    }
   }
   query += " ORDER BY completed_at DESC";
   return await execute("recentBuilds", query, queryParams);

--- a/views/history/builds.pug
+++ b/views/history/builds.pug
@@ -18,6 +18,8 @@ block content
           +formSelect("Build Key", "buildKey", buildKeyList, buildKeyFilter)
         div(class="w-1/5 px-3 mb-6 md:mb-0")
           +formSelect("Repository", "repository", repositoryList, repositoryFilter)
+        div(class="w-1/5 px-3 mb-6 md:mb-0")
+          +formSelect("Source", "source", sourceList, sourceFilter)
       div(class="w-1/4 px-3 mb-6 md:mb-0")
         button(class="bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded") Filter
 


### PR DESCRIPTION
This PR adds Source as an additional filter on the History | Builds screen. This allows you to more quickly find particular builds such as a `release` or `branch` build.

closes #465 
