### PR TITLE
🐛 Fixed a bug if sys defaults or overrides not set

### DIFF
--- a/lib/cache/cache.js
+++ b/lib/cache/cache.js
@@ -143,7 +143,9 @@ async function storeSystemDefaults(defaults) {
  * @return {*} defaults
  */
 async function fetchSystemDefaults() {
-  const defaults = await client.fetch("stampede-config-defaults");
+  const defaults = await client.fetch("stampede-config-defaults", {
+    defaults: {},
+  });
   return defaults;
 }
 
@@ -181,7 +183,9 @@ async function storeSystemOverrides(overrides) {
  * @return {*} overrides
  */
 async function fetchSystemOverrides() {
-  const overrides = await client.fetch("stampede-config-overrides");
+  const overrides = await client.fetch("stampede-config-overrides", {
+    overrides: {},
+  });
   return overrides;
 }
 


### PR DESCRIPTION
This PR fixes a bug that was causing a crash if the system defaults or system overrides didn't have anything set in them.

closes #360 