### PR TITLE
♻️ Changed how single check run rerequest is handled

### DIFF
--- a/events/checkRun.js
+++ b/events/checkRun.js
@@ -26,7 +26,7 @@ async function handle(body, dependencies) {
   await dependencies.db.storeRepository(event.owner, event.repo);
 
   if (event.action === "rerequested") {
-    await requeueTask(event.checkRunID, dependencies);
+    await requeueTask(event.externalID, dependencies);
   } else if (event.action === "requested_action") {
     for (let index = 0; index < event.pullRequests.length; index++) {
       await checkRun.createCheckRunForAction(

--- a/events/checkSuite.js
+++ b/events/checkSuite.js
@@ -6,25 +6,24 @@ const notification = require("../lib/notification");
 /**
  * handle event
  * @param {*} body
- * @param {*} serverConf
- * @param {*} cache
+ * @param {*} dependencies
  * @return {Object} response to the event
  */
-async function handle(body, serverConf, cache, scm, db, logger) {
+async function handle(body, dependencies) {
   // Parse the incoming body into the parts we care about
   const event = parseEvent(body);
-  logger.info("CheckSuiteEvent:");
-  if (serverConf.logLevel === "verbose") {
-    logger.verbose(JSON.stringify(event, null, 2));
+  dependencies.logger.info("CheckSuiteEvent:");
+  if (dependencies.serverConfig.logLevel === "verbose") {
+    dependencies.logger.verbose(JSON.stringify(event, null, 2));
   }
   notification.repositoryEventReceived("check_suite", event);
 
   // Ignore check_suite events not for this app
-  if (event.appID !== parseInt(serverConf.githubAppID)) {
+  if (event.appID !== parseInt(dependencies.serverConfig.githubAppID)) {
     return { status: "ignored, not our app id" };
   }
 
-  await db.storeRepository(event.owner, event.repo);
+  await dependencies.db.storeRepository(event.owner, event.repo);
 
   // Ignore actions we don't care about
   if (event.action !== "rerequested") {
@@ -40,11 +39,11 @@ async function handle(body, serverConf, cache, scm, db, logger) {
       event.pullRequests[index],
       event.cloneURL,
       event.sshURL,
-      scm,
-      cache,
-      serverConf,
-      db,
-      logger
+      dependencies.scm,
+      dependencies.cache,
+      dependencies.serverConfig,
+      dependencies.db,
+      dependencies.logger
     );
   }
   return { status: "check runs created" };

--- a/events/pullRequest.js
+++ b/events/pullRequest.js
@@ -8,19 +8,18 @@ const build = require("../lib/build");
 /**
  * handle event
  * @param {*} body
- * @param {*} serverConf
- * @param {*} cache
+ * @param {*} dependencies
  */
-async function handle(body, serverConf, cache, scm, db, logger) {
+async function handle(body, dependencies) {
   // Parse the incoming body into the parts we care about
   const event = parseEvent(body);
-  logger.info("PullRequestEvent:");
-  if (serverConf.logLevel === "verbose") {
-    logger.verbose(JSON.stringify(event, null, 2));
+  dependencies.logger.info("PullRequestEvent:");
+  if (dependencies.serverConfig.logLevel === "verbose") {
+    dependencies.logger.verbose(JSON.stringify(event, null, 2));
   }
   notification.repositoryEventReceived("pull_request", event);
 
-  await db.storeRepository(event.owner, event.repo);
+  await dependencies.db.storeRepository(event.owner, event.repo);
 
   if (
     event.action === "opened" ||
@@ -34,11 +33,11 @@ async function handle(body, serverConf, cache, scm, db, logger) {
       event.pullRequest,
       event.cloneURL,
       event.sshURL,
-      scm,
-      cache,
-      serverConf,
-      db,
-      logger
+      dependencies.scm,
+      dependencies.cache,
+      dependencies.serverConfig,
+      dependencies.db,
+      dependencies.logger
     );
     return { status: "pull request tasks created" };
   } else if (event.action === "edited") {
@@ -49,11 +48,11 @@ async function handle(body, serverConf, cache, scm, db, logger) {
       event.pullRequest,
       event.cloneURL,
       event.sshURL,
-      scm,
-      cache,
-      serverConf,
-      db,
-      logger
+      dependencies.scm,
+      dependencies.cache,
+      dependencies.serverConfig,
+      dependencies.db,
+      dependencies.logger
     );
   } else {
     return { status: "ignored, pull request not opened or reopened" };
@@ -163,7 +162,7 @@ async function pullRequestEdit(
   };
 
   const scmDetails = {
-    id: serverConf.scm,
+    id: dependencies.serverConfig.scm,
     cloneURL: cloneURL,
     sshURL: sshURL,
     pullRequest: pullRequestDetails,

--- a/lib/incomingHandler.js
+++ b/lib/incomingHandler.js
@@ -10,58 +10,20 @@ const releaseEvent = require("../events/release");
 /**
  * handle task update
  * @param {*} job
- * @param {*} conf
- * @param {*} cache
- * @param {*} scm
- * @param {*} db
+ * @param {*} dependencies
  */
 async function handle(job, dependencies) {
   try {
     if (job.event === "check_suite") {
-      await checkSuiteEvent.handle(
-        job.body,
-        dependencies.serverConfig,
-        dependencies.cache,
-        dependencies.scm,
-        dependencies.db,
-        dependencies.logger
-      );
+      await checkSuiteEvent.handle(job.body, dependencies);
     } else if (job.event === "check_run") {
-      await checkRunEvent.handle(
-        job.body,
-        dependencies.serverConfig,
-        dependencies.cache,
-        dependencies.scm,
-        dependencies.db,
-        dependencies.logger
-      );
+      await checkRunEvent.handle(job.body, dependencies);
     } else if (job.event === "pull_request") {
-      await pullRequestEvent.handle(
-        job.body,
-        dependencies.serverConfig,
-        dependencies.cache,
-        dependencies.scm,
-        dependencies.db,
-        dependencies.logger
-      );
+      await pullRequestEvent.handle(job.body, dependencies);
     } else if (job.event === "push") {
-      await pushEvent.handle(
-        job.body,
-        dependencies.serverConfig,
-        dependencies.cache,
-        dependencies.scm,
-        dependencies.db,
-        dependencies.logger
-      );
+      await pushEvent.handle(job.body, dependencies);
     } else if (job.event === "release") {
-      await releaseEvent.handle(
-        job.body,
-        dependencies.serverConfig,
-        dependencies.cache,
-        dependencies.scm,
-        dependencies.db,
-        dependencies.logger
-      );
+      await releaseEvent.handle(job.body, dependencies);
     }
   } catch (e) {
     dependencies.logger.error("Error handling incoming message: " + e);


### PR DESCRIPTION
This PR changes how a single check run is handled. Previously, when the user asked to re-run a single check, the entire set of checks would start because of reasons. Now only the single check run should re-run. This PR also changes all the event handlers for Github events, so might introduce other issues, but we will just need to do some testing.

![dont-panic](https://user-images.githubusercontent.com/140127/92326207-745a9500-f01e-11ea-960c-290f366967fb.jpg)


closes #42 
