### PR TITLE
✨ Build key not filters by repository on build history

### DIFF
--- a/controllers/history/builds.js
+++ b/controllers/history/builds.js
@@ -22,16 +22,19 @@ async function handle(req, res, dependencies, owners) {
     buildKeyFilter = req.query.buildKey;
   }
 
-  const buildKeyRows = await dependencies.db.fetchRecentBuildKeys(timeFilter);
+  let repositoryFilter = "All";
+  if (req.query.repository != null) {
+    repositoryFilter = req.query.repository;
+  }
+
+  const buildKeyRows = await dependencies.db.fetchRecentBuildKeys(
+    timeFilter,
+    repositoryFilter
+  );
   let buildKeyList = [];
   buildKeyList.push("All");
   for (let index = 0; index < buildKeyRows.rows.length; index++) {
     buildKeyList.push(buildKeyRows.rows[index].build_key);
-  }
-
-  let repositoryFilter = "All";
-  if (req.query.repository != null) {
-    repositoryFilter = req.query.repository;
   }
 
   const repositoriesRows = await dependencies.db.fetchRepositories();

--- a/lib/db.js
+++ b/lib/db.js
@@ -746,7 +746,7 @@ async function fetchBuildTimePerNode(timeFilter) {
 /**
  * fetchRecentBuildKeys
  */
-async function fetchRecentBuildKeys(timeFilter) {
+async function fetchRecentBuildKeys(timeFilter, repositoryFilter) {
   let fromDate = new Date();
   let toDate = new Date();
   if (timeFilter === "Last 8 hours") {
@@ -774,13 +774,21 @@ async function fetchRecentBuildKeys(timeFilter) {
     fromDate = moment().subtract(30, "days").toDate();
     fromDate.setHours(0, 0, 0, 0);
   }
+  const queryParams = [fromDate, toDate];
 
-  const query =
+  let query =
     "SELECT DISTINCT build_key from stampede.builds WHERE \
     completed_at >= $1 AND \
-    completed_at <= $2 \
-    ORDER BY build_key";
-  const queryParams = [fromDate, toDate];
+    completed_at <= $2";
+
+  if (repositoryFilter != "All") {
+    query += " AND owner = $" + (queryParams.length + 1);
+    query += " AND repository = $" + (queryParams.length + 2);
+    queryParams.push(repositoryFilter.split("/")[0]);
+    queryParams.push(repositoryFilter.split("/")[1]);
+  }
+
+  query += " ORDER BY build_key";
   return await execute("fetchRecentBuildKeys", query, queryParams);
 }
 


### PR DESCRIPTION
This PR adds an additional filter to the build key on the build history screen. Now if you select a repository and filter on that, the build key will filter the list to show only build keys found in the repository selected.

closes #348 