### PR TITLE
✨ New report for viewing parameter values across a task

### DIFF
--- a/controllers/admin/reports/taskParameterValues.js
+++ b/controllers/admin/reports/taskParameterValues.js
@@ -1,0 +1,120 @@
+/**
+ * path this handler will serve
+ */
+function path() {
+  return "/admin/reports/taskParameterValues";
+}
+
+/**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
+ * handle dailySummary
+ * @param {*} req
+ * @param {*} res
+ * @param {*} dependencies
+ */
+async function handle(req, res, dependencies, owners) {
+  const parameters = [];
+
+  let timeFilter = "Last 8 hours";
+  if (req.query.time != null) {
+    timeFilter = req.query.time;
+  }
+
+  let taskFilter = "None";
+  if (req.query.task != null) {
+    taskFilter = req.query.task;
+  }
+
+  const taskList = await dependencies.cache.fetchTasks();
+  const sortedTasks = taskList != null ? taskList.sort() : [];
+  sortedTasks.unshift("None");
+
+  const tasks = await dependencies.db.recentTasks(
+    timeFilter,
+    taskFilter,
+    "All",
+    "All",
+    "All",
+    "Date DESC"
+  );
+
+  if (tasks != null) {
+    for (let index = 0; index < tasks.rows.length; index++) {
+      const details = await dependencies.db.fetchTaskDetails(
+        tasks.rows[index].task_id
+      );
+      if (details != null && details.rows.length > 0) {
+        const taskDetails = details.rows[0];
+        if (taskDetails.details.config != null) {
+          Object.keys(taskDetails.details.config).forEach(function (key) {
+            let found = false;
+            for (let pindex = 0; pindex < parameters.length; pindex++) {
+              if (
+                parameters[pindex].key === key &&
+                parameters[pindex].value ===
+                  taskDetails.details.config[key].value &&
+                parameters[pindex].repository ===
+                  taskDetails.details.owner +
+                    "/" +
+                    taskDetails.details.repository
+              ) {
+                parameters[pindex].count = parameters[pindex].count + 1;
+                found = true;
+              }
+            }
+
+            if (!found) {
+              parameters.push({
+                key: key,
+                value: taskDetails.details.config[key].value,
+                count: 1,
+                repository:
+                  taskDetails.details.owner +
+                  "/" +
+                  taskDetails.details.repository,
+              });
+            }
+          });
+        }
+      }
+    }
+  }
+
+  const sortedParameters = parameters.sort(function (a, b) {
+    if (a.key < b.key) {
+      return -1;
+    } else if (a.key > b.key) {
+      return 1;
+    } else {
+      return 0;
+    }
+  });
+
+  res.render(dependencies.viewsPath + "admin/reports/taskParameterValues", {
+    owners: owners,
+    isAdmin: req.validAdminSession,
+    parameters: sortedParameters,
+    timeFilter: timeFilter,
+    timeFilterList: [
+      "Last 8 hours",
+      "Last 12 hours",
+      "Today",
+      "Yesterday",
+      "Last 3 Days",
+      "Last 7 Days",
+      "Last 14 Days",
+      "Last 30 Days",
+    ],
+    taskFilter: taskFilter,
+    taskList: sortedTasks,
+  });
+}
+
+module.exports.path = path;
+module.exports.handle = handle;

--- a/views/admin/reports.pug
+++ b/views/admin/reports.pug
@@ -36,3 +36,6 @@ block content
             +tableRow('/history/buildTimeByNode')
                 +tableCell('Build Time by Node')
                 +tableCell('View a chart of build time grouped by node')
+            +tableRow('/admin/reports/taskParameterValues')
+                +tableCell('Task Parameter Values')
+                +tableCell('View parameter values across all executions of a single task')

--- a/views/admin/reports/taskParameterValues.pug
+++ b/views/admin/reports/taskParameterValues.pug
@@ -1,0 +1,39 @@
+extends ../../layout
+include ../../components/titleBar
+include ../../components/formSelect
+include ../../components/infoCard
+include ../../components/infoCardPair
+include ../../components/tableRow
+include ../../components/tableCell
+include ../../components/tableHeader
+
+block content
+
+  +titleBar([{title: 'Task Parameter Values'}])
+
+  div(class="flex flex-wrap m-4")
+    form(class="w-full m-4" method="GET" action="/admin/reports/taskParameterValues")
+      div(class="flex -mx-3 mb-6")
+        div(class="w-1/5 px-3 mb-6 md:mb-0")
+          +formSelect("Time", "time", timeFilterList, timeFilter)
+        div(class="w-1/5 px-3 mb-6 md:mb-0")
+          +formSelect("Task", "task", taskList, taskFilter)
+      div(class="w-1/4 px-3 mb-6 md:mb-0")
+        button(class="bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded") Filter
+
+  hr
+
+  +infoCard('Config Parameters')
+    table(class="table-auto w-full")
+        thead
+            +tableHeader('Config Parameter')
+            +tableHeader('Value')
+            +tableHeader('Count')
+            +tableHeader('Repository')
+        tbody
+            each param, i in parameters
+                +tableRow()
+                    +tableCell(param.key)
+                    +tableCell(param.value)
+                    +tableCell(param.count)
+                    +tableCell(param.repository)


### PR DESCRIPTION
This PR adds a new admin report that will show all the values for parameters used in a task, across all executions/repositories for that task. So if you want to see how different repositories are using different values this report makes that easy to find. For example this can be used to see which projects are using which version of Xcode in a specific task.

Note that this only works for a single task at a time. Also for larger date ranges this is not a fast operation.

closes #529