### PR TITLE
✨Artifacts table

### DIFF
--- a/bin/stampede-server.js
+++ b/bin/stampede-server.js
@@ -12,6 +12,7 @@ const winston = require("winston");
 const web = require("../lib/web");
 const taskQueue = require("../lib/taskQueue");
 const taskUpdate = require("../lib/taskUpdate");
+const taskArtifact = require("../lib/taskArtifact");
 const notification = require("../lib/notification");
 const db = require("../lib/db");
 const incomingHandler = require("../lib/incomingHandler");
@@ -174,6 +175,8 @@ if (conf.handleResponseQueue === "enabled") {
   responseQueue.process(function (job) {
     if (job.data.response === "taskUpdate") {
       return taskUpdate.handle(job.data.payload, conf, cache, scm, db, logger);
+    } else if (job.data.response === "taskArtifact") {
+      return taskArtifact.handle(job.data.payload, dependencies);
     } else if (job.data.response === "heartbeat") {
       cache.storeWorkerHeartbeat(job.data.payload);
       notification.workerHeartbeat(job.data.payload);

--- a/controllers/history/buildDetails.js
+++ b/controllers/history/buildDetails.js
@@ -47,6 +47,12 @@ async function handle(req, res, dependencies, owners) {
         artifacts.push(taskResultDetails.details.result.artifacts[aindex]);
       }
     }
+    const artifactRows = await dependencies.db.fetchTaskArtifacts(task.task_id);
+    if (artifactRows != null && artifactRows.rows != null) {
+      for (let aindex = 0; aindex < artifactRows.rows.length; aindex++) {
+        artifacts.push(artifactRows.rows[aindex]);
+      }
+    }
   }
   res.render(dependencies.viewsPath + "history/buildDetails", {
     owners: owners,

--- a/controllers/history/buildTaskDetails.js
+++ b/controllers/history/buildTaskDetails.js
@@ -92,6 +92,15 @@ async function handle(req, res, dependencies, owners) {
         });
       }
     }
+    const artifactRows = await dependencies.db.fetchTaskArtifacts(
+      req.query.taskID
+    );
+    if (artifactRows != null && artifactRows.rows != null) {
+      for (let aindex = 0; aindex < artifactRows.rows.length; aindex++) {
+        artifacts.push(artifactRows.rows[aindex]);
+      }
+    }
+
     const buildRows = await dependencies.db.fetchBuild(task.build_id);
     const build = buildRows.rows[0];
 

--- a/controllers/history/taskDetails.js
+++ b/controllers/history/taskDetails.js
@@ -106,6 +106,15 @@ async function handle(req, res, dependencies, owners) {
     }
   }
 
+  const artifactRows = await dependencies.db.fetchTaskArtifacts(
+    req.query.taskID
+  );
+  if (artifactRows != null && artifactRows.rows != null) {
+    for (let aindex = 0; aindex < artifactRows.rows.length; aindex++) {
+      artifacts.push(artifactRows.rows[aindex]);
+    }
+  }
+
   res.render(dependencies.viewsPath + "history/taskDetails", {
     owners: owners,
     isAdmin: req.validAdminSession,

--- a/controllers/monitor/buildDetails.js
+++ b/controllers/monitor/buildDetails.js
@@ -47,6 +47,12 @@ async function handle(req, res, dependencies, owners) {
         artifacts.push(taskResultDetails.details.result.artifacts[aindex]);
       }
     }
+    const artifactRows = await dependencies.db.fetchTaskArtifacts(task.task_id);
+    if (artifactRows != null && artifactRows.rows != null) {
+      for (let aindex = 0; aindex < artifactRows.rows.length; aindex++) {
+        artifacts.push(artifactRows.rows[aindex]);
+      }
+    }
   }
   res.render(dependencies.viewsPath + "monitor/buildDetails", {
     owners: owners,

--- a/controllers/monitor/buildTaskDetails.js
+++ b/controllers/monitor/buildTaskDetails.js
@@ -99,6 +99,15 @@ async function handle(req, res, dependencies, owners) {
       });
     }
 
+    const artifactRows = await dependencies.db.fetchTaskArtifacts(
+      req.query.taskID
+    );
+    if (artifactRows != null && artifactRows.rows != null) {
+      for (let aindex = 0; aindex < artifactRows.rows.length; aindex++) {
+        artifacts.push(artifactRows.rows[aindex]);
+      }
+    }
+
     res.render(dependencies.viewsPath + "monitor/buildTaskDetails", {
       owners: owners,
       isAdmin: req.validAdminSession,

--- a/controllers/repositories/buildDetails.js
+++ b/controllers/repositories/buildDetails.js
@@ -47,6 +47,12 @@ async function handle(req, res, dependencies, owners) {
         artifacts.push(taskResultDetails.details.result.artifacts[aindex]);
       }
     }
+    const artifactRows = await dependencies.db.fetchTaskArtifacts(task.task_id);
+    if (artifactRows != null && artifactRows.rows != null) {
+      for (let aindex = 0; aindex < artifactRows.rows.length; aindex++) {
+        artifacts.push(artifactRows.rows[aindex]);
+      }
+    }
   }
   res.render(dependencies.viewsPath + "repositories/buildDetails", {
     owners: owners,

--- a/controllers/repositories/taskDetails.js
+++ b/controllers/repositories/taskDetails.js
@@ -105,6 +105,15 @@ async function handle(req, res, dependencies, owners) {
     }
   }
 
+  const artifactRows = await dependencies.db.fetchTaskArtifacts(
+    req.query.taskID
+  );
+  if (artifactRows != null && artifactRows.rows != null) {
+    for (let aindex = 0; aindex < artifactRows.rows.length; aindex++) {
+      artifacts.push(artifactRows.rows[aindex]);
+    }
+  }
+
   res.render(dependencies.viewsPath + "repositories/taskDetails", {
     owners: owners,
     isAdmin: req.validAdminSession,

--- a/lib/db.js
+++ b/lib/db.js
@@ -641,7 +641,7 @@ async function storeTaskDetailsUpdate(taskID, details) {
 }
 
 /**
- * storeTaskArtifacts
+ * storeTaskArtifact
  */
 async function storeTaskArtifact(taskID, title, type, url, contents, metadata) {
   const insert =

--- a/lib/db.js
+++ b/lib/db.js
@@ -641,6 +641,46 @@ async function storeTaskDetailsUpdate(taskID, details) {
 }
 
 /**
+ * storeTaskArtifacts
+ */
+async function storeTaskArtifact(taskID, title, type, url, contents, metadata) {
+  const insert =
+    "INSERT INTO stampede.taskArtifacts (task_id, title, type, url, created_at, contents, metadata) \
+  VALUES ($1, $2, $3, $4, $5, $6, $7)";
+  return await execute("storeTaskArtifacts", insert, [
+    taskID,
+    title,
+    type,
+    url,
+    new Date(),
+    contents,
+    metadata,
+  ]);
+}
+
+/**
+ * fetchTaskArtifacts
+ * @param {string} taskID
+ */
+async function fetchTaskArtifacts(taskID) {
+  const query =
+    "SELECT title, type, url from stampede.taskArtifacts WHERE \
+  task_id = $1;";
+  return await execute("fetchTaskArtifacts", query, [taskID]);
+}
+
+/**
+ * fetchTaskContents
+ * @param {*} taskID
+ * @param {*} title
+ */
+async function fetchTaskContents(taskID, title) {
+  const query =
+    "SELECT contents from stampede.taskArtifacts WHERE task_id = $1 and title = $2";
+  return await execute("fetchTaskContents", query, [taskID, title]);
+}
+
+/**
  * fetchNodes
  */
 async function fetchNodes() {
@@ -1028,6 +1068,18 @@ async function createTables(client) {
   );
 
   await client.query(
+    "CREATE TABLE IF NOT EXISTS stampede.taskArtifacts \
+    (task_id varchar, \
+      title varchar, \
+      type varchar, \
+      url varchar, \
+      created_at timestamptz, \
+      contents jsonb, \
+      metadata jsonb, \
+      PRIMARY KEY (task_id, title))"
+  );
+
+  await client.query(
     "CREATE TABLE IF NOT EXISTS stampede.version \
     (version int);"
   );
@@ -1118,6 +1170,10 @@ module.exports.summarizeHourlyTasks = summarizeHourlyTasks;
 module.exports.storeTaskDetails = storeTaskDetails;
 module.exports.storeTaskDetailsUpdate = storeTaskDetailsUpdate;
 module.exports.fetchTaskDetails = fetchTaskDetails;
+
+module.exports.storeTaskArtifact = storeTaskArtifact;
+module.exports.fetchTaskArtifacts = fetchTaskArtifacts;
+module.exports.fetchTaskContents = fetchTaskContents;
 
 module.exports.fetchNodes = fetchNodes;
 

--- a/lib/taskArtifact.js
+++ b/lib/taskArtifact.js
@@ -1,0 +1,26 @@
+"use strict";
+
+/**
+ * handle task artifact
+ * @param {*} event
+ * @param {*} dependencies
+ */
+async function handle(event, dependencies) {
+  try {
+    const taskID = event.taskID;
+    dependencies.logger.verbose("taskArtifact: " + taskID);
+
+    await dependencies.db.storeTaskArtifact(
+      taskID,
+      event.title,
+      event.type,
+      event.url,
+      event.contents,
+      event.metadata
+    );
+  } catch (e) {
+    dependencies.logger.error(e);
+  }
+}
+
+module.exports.handle = handle;

--- a/lib/taskUpdate.js
+++ b/lib/taskUpdate.js
@@ -47,8 +47,8 @@ async function handle(job, serverConf, cache, scm, db, logger) {
               event.result.artifacts[aindex].title,
               event.result.artifacts[aindex].type,
               event.result.artifacts[aindex].url,
-              null,
-              null
+              event.result.artifacts[aindex].contents,
+              event.result.artifacts[aindex].metadata
             );
           }
           event.result.artifacts = [];

--- a/lib/taskUpdate.js
+++ b/lib/taskUpdate.js
@@ -31,6 +31,29 @@ async function handle(job, serverConf, cache, scm, db, logger) {
           event.stats.completedAt,
           event.result.conclusion
         );
+
+        // Strip out the artifacts returned and store them in their own table
+        // instead of leaving them in the task details JSON. This ensures backward
+        // compatibility with existing workers. Note that workers can also send
+        // separate events to store task artifact details.
+        if (event.result.artifacts) {
+          for (
+            let aindex = 0;
+            aindex < event.result.artifacts.length;
+            aindex++
+          ) {
+            await db.storeTaskArtifact(
+              event.taskID,
+              event.result.artifacts[aindex].title,
+              event.result.artifacts[aindex].type,
+              event.result.artifacts[aindex].url,
+              null,
+              null
+            );
+          }
+          event.result.artifacts = [];
+        }
+
         await db.storeTaskDetailsUpdate(event.taskID, event);
       } catch (e) {
         logger.error("Error storing task completed details: " + e);
@@ -54,7 +77,7 @@ async function handle(job, serverConf, cache, scm, db, logger) {
           owner: event.owner,
           repo: event.repository,
           buildKey: event.buildKey,
-          buildNumber: event.buildNumber
+          buildNumber: event.buildNumber,
         });
       }
     } else {
@@ -82,7 +105,7 @@ async function handle(job, serverConf, cache, scm, db, logger) {
       owner: event.owner,
       repo: event.repository,
       status: event.status,
-      check_run_id: event.scm.checkRunID
+      check_run_id: event.scm.checkRunID,
     };
 
     if (event.result != null) {
@@ -95,7 +118,7 @@ async function handle(job, serverConf, cache, scm, db, logger) {
         update.output = {
           title: event.result.title,
           summary: event.result.summary != null ? event.result.summary : "",
-          text: event.result.text != null ? event.result.text : ""
+          text: event.result.text != null ? event.result.text : "",
         };
       }
     }


### PR DESCRIPTION
This PR modifies the server to include an artifacts table that stores all the task artifacts. Previously this data was a part of the taskDetails json object, but moving this to its own table has some benefits for accessing artifacts more quickly. This will open up functionality in the future for viewing artifacts in Stampede directly, along with doing diff comparisons between branches or between a PR and a default branch.

Note: This PR is backward compatible with worker instances and existing task details that contain artifacts in the JSON. There is no migration code here to move artifacts from taskDetails, although that might be something we could add in the future if needed.

closes #508 