### PR TITLE
✨ Added notification channel config to admin screens

### DIFF
--- a/controllers/admin/notifications/channelConfig.js
+++ b/controllers/admin/notifications/channelConfig.js
@@ -1,0 +1,37 @@
+/**
+ * path this handler will serve
+ */
+function path() {
+  return "/admin/notifications/channelConfig";
+}
+
+/**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
+ * handle tasks
+ * @param {*} req
+ * @param {*} res
+ * @param {*} dependencies
+ */
+async function handle(req, res, dependencies, owners) {
+  const channelConfig = await dependencies.cache.notifications.fetchNotificationChannelConfig(
+    req.query.channelID
+  );
+
+  res.render(dependencies.viewsPath + "admin/notifications/channelConfig", {
+    owners: owners,
+    isAdmin: req.validAdminSession,
+    channelID: req.query.channelID,
+    title: channelConfig.title,
+    config: channelConfig.config,
+  });
+}
+
+module.exports.path = path;
+module.exports.requiresAdmin = requiresAdmin;
+module.exports.handle = handle;

--- a/controllers/admin/notifications/notificationChannels.js
+++ b/controllers/admin/notifications/notificationChannels.js
@@ -1,0 +1,56 @@
+const { loggers } = require("winston");
+
+/**
+ * path this handler will serve
+ */
+function path() {
+  return "/admin/notifications/notificationChannels";
+}
+
+/**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
+ * handle tasks
+ * @param {*} req
+ * @param {*} res
+ * @param {*} dependencies
+ */
+async function handle(req, res, dependencies, owners) {
+  const channelList = await dependencies.cache.notifications.fetchNotificationChannels();
+  const sortedChannels = channelList.sort();
+  const channels = [];
+  for (let index = 0; index < sortedChannels.length; index++) {
+    const channelConfig = await dependencies.cache.notifications.fetchNotificationChannelConfig(
+      sortedChannels[index]
+    );
+    if (channelConfig != null) {
+      channels.push({
+        id: sortedChannels[index],
+        title: channelConfig.title,
+      });
+    } else {
+      dependencies.logger.error("Unable to locate channel config");
+      channels.push({
+        id: sortedChannels[index],
+        title: "unknown",
+      });
+    }
+  }
+  res.render(
+    dependencies.viewsPath + "admin/notifications/notificationChannels",
+    {
+      owners: owners,
+      isAdmin: req.validAdminSession,
+      channels: channels,
+    }
+  );
+}
+
+module.exports.path = path;
+module.exports.requiresAdmin = requiresAdmin;
+module.exports.handle = handle;

--- a/controllers/admin/notifications/removeChannel.js
+++ b/controllers/admin/notifications/removeChannel.js
@@ -1,0 +1,49 @@
+const yaml = require("js-yaml");
+const { loggers } = require("winston");
+
+/**
+ * path this handler will serve
+ */
+function path() {
+  return "/admin/notifications/removeChannel";
+}
+
+/**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
+ * http method this handler will serve
+ */
+function method() {
+  return "post";
+}
+
+/**
+ * handle tasks
+ * @param {*} req
+ * @param {*} res
+ * @param {*} dependencies
+ */
+async function handle(req, res, dependencies, owners) {
+  try {
+    const channelID = req.body.channelID;
+    await dependencies.cache.notifications.removeNotificationChannelConfig(
+      channelID
+    );
+  } catch (e) {
+    dependencies.logger.error("Error removing channel: " + e);
+  }
+  res.writeHead(301, {
+    Location: "/admin/notifications/notificationChannels",
+  });
+  res.end();
+}
+
+module.exports.path = path;
+module.exports.method = method;
+module.exports.requiresAdmin = requiresAdmin;
+module.exports.handle = handle;

--- a/controllers/admin/notifications/uploadChannel.js
+++ b/controllers/admin/notifications/uploadChannel.js
@@ -1,0 +1,56 @@
+const yaml = require("js-yaml");
+
+/**
+ * path this handler will serve
+ */
+function path() {
+  return "/admin/notifications/uploadChannel";
+}
+
+/**
+ * http method this handler will serve
+ */
+function method() {
+  return "post";
+}
+
+/**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
+ * handle tasks
+ * @param {*} req
+ * @param {*} res
+ * @param {*} dependencies
+ */
+async function handle(req, res, dependencies) {
+  if (req.files != null) {
+    const uploadData = req.files.uploadFile;
+    const channelConfig = yaml.safeLoad(uploadData.data);
+    if (channelConfig != null) {
+      if (channelConfig.id != null) {
+        await dependencies.cache.notifications.storeNotificationChannel(
+          channelConfig.id
+        );
+        await dependencies.cache.notifications.storeNotificationChannelConfig(
+          channelConfig.id,
+          channelConfig
+        );
+      }
+    }
+  }
+
+  res.writeHead(301, {
+    Location: "/admin/notifications/notificationChannels",
+  });
+  res.end();
+}
+
+module.exports.path = path;
+module.exports.method = method;
+module.exports.requiresAdmin = requiresAdmin;
+module.exports.handle = handle;

--- a/lib/cache/cache.js
+++ b/lib/cache/cache.js
@@ -10,6 +10,7 @@ const repoConfigOverrides = require("./repoConfigOverrides");
 const systemQueues = require("./systemQueues");
 const repositoryBuilds = require("./repositoryBuilds");
 const admin = require("./admin");
+const notifications = require("./notifications");
 
 // Public functions
 
@@ -28,6 +29,7 @@ function startCache(conf) {
   systemQueues.setClient(client);
   repositoryBuilds.setClient(client);
   admin.setClient(client);
+  notifications.setClient(client);
 }
 
 /**
@@ -424,3 +426,4 @@ module.exports.repoConfigOverrides = repoConfigOverrides;
 module.exports.systemQueues = systemQueues;
 module.exports.repositoryBuilds = repositoryBuilds;
 module.exports.admin = admin;
+module.exports.notifications = notifications;

--- a/lib/cache/notifications.js
+++ b/lib/cache/notifications.js
@@ -1,0 +1,58 @@
+"use strict";
+
+let client;
+
+function setClient(redisClient) {
+  client = redisClient;
+}
+
+/**
+ * fetchNotificationChannels
+ */
+async function fetchNotificationChannels() {
+  const channels = await client.fetchMembers("stampede-notification-channels");
+  return channels;
+}
+
+/**
+ * fetchChannelConfig
+ * @param {*} id
+ * @return {Object} channel config
+ */
+async function fetchNotificationChannelConfig(id) {
+  const config = await client.fetch("stampede-notification-channel-" + id);
+  return config;
+}
+
+/**
+ * removeNotificationChannelConfig
+ * @param {*} id
+ */
+async function removeNotificationChannelConfig(id) {
+  await client.remove("stampede-notification-channel-" + id);
+  await client.removeMember("stampede-notification-channels", id);
+}
+
+/**
+ * storeNotificationChannel
+ * @param {*} id
+ */
+async function storeNotificationChannel(id) {
+  await client.add("stampede-notification-channels", id);
+}
+
+/**
+ * storeNotificationChannelConfig
+ * @param {*} id
+ * @param {*} config
+ */
+async function storeNotificationChannelConfig(id, config) {
+  await client.store("stampede-notification-channel-" + id, config);
+}
+
+module.exports.setClient = setClient;
+module.exports.fetchNotificationChannels = fetchNotificationChannels;
+module.exports.fetchNotificationChannelConfig = fetchNotificationChannelConfig;
+module.exports.removeNotificationChannelConfig = removeNotificationChannelConfig;
+module.exports.storeNotificationChannel = storeNotificationChannel;
+module.exports.storeNotificationChannelConfig = storeNotificationChannelConfig;

--- a/views/admin/notifications/channelConfig.pug
+++ b/views/admin/notifications/channelConfig.pug
@@ -1,0 +1,47 @@
+extends ../../layout
+include ../../components/titleBar
+include ../../components/tableHeader
+include ../../components/tableCell
+include ../../components/tableRow
+include ../../components/formHidden
+
+block content
+
+  +titleBar([{title: 'Notification Channels', href: '/admin/notifications/notificationChannels'}, {title: taskID}])
+  div(class="flex flex-wrap m-4")
+
+    div(class="w-full md:w-1/2 xl:w-1/3 p-3")
+      div(class="bg-white border-transparent rounded-lg shadow-lg")
+        div(class="bg-gray-400 uppercase text-gray-800 border-b-2 border-gray-500 rounded-tl-lg rounded-tr-lg p-2")
+          h5(class="font-bold uppercase text-gray-600") Channel Information
+        div(class="p-5")
+          table(class="table-auto w-full")
+            tbody
+              +tableRow()
+                +tableCell(channelID)
+              +tableRow()
+                +tableCell(title)
+
+    div(class="w-full md:w-1/2 xl:w-1/3 p-3")
+      div(class="bg-white border-transparent rounded-lg shadow-lg")
+        div(class="bg-gray-400 uppercase text-gray-800 border-b-2 border-gray-500 rounded-tl-lg rounded-tr-lg p-2")
+          h5(class="font-bold uppercase text-gray-600") Config Parameters
+        div(class="p-5")
+          table(class="table-auto w-full")
+            tbody
+              each value,param in config
+                +tableRow()
+                  +tableCell(param)
+                  +tableCell(value)
+
+  hr
+  div(class="w-full p-3")
+    div(class="bg-white border-transparent rounded-lg shadow-lg")
+      div(class="bg-gray-400 uppercase text-gray-800 border-b-2 border-gray-500 rounded-tl-lg rounded-tr-lg p-2")
+        h5(class="font-bold uppercase text-gray-600") Remove channel
+      div(class="p-5")
+        form(class="w-full m-4" method="POST" action="/admin/notifications/removeChannel" encType="multipart/form-data")
+          div(class="w-1/2 px-3 mb-6 md:mb-0")
+            +formHidden('channelID', channelID)
+            button(class="bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded") Remove Channel
+

--- a/views/admin/notifications/notificationChannels.pug
+++ b/views/admin/notifications/notificationChannels.pug
@@ -1,0 +1,36 @@
+extends ../../layout
+include ../../components/titleBar
+include ../../components/tableHeader
+include ../../components/tableCell
+include ../../components/tableRow
+include ../../components/formFile
+
+block content
+
+  +titleBar([{title: 'Notification Channels'}])
+  div(class="flex flex-wrap m-4")
+
+    table(class="table-auto w-full")
+      thead
+        tr
+          +tableHeader('Channel ID')
+          +tableHeader('Title')
+      tbody
+        each channel, i in channels
+          +tableRow(`/admin/notifications/channelConfig?channelID=` + channel.id)
+            +tableCell(channel.id)
+            +tableCell(channel.title)
+
+  hr
+  div(class="w-full p-3")
+    div(class="bg-white border-transparent rounded-lg shadow-lg")
+      div(class="bg-gray-400 uppercase text-gray-800 border-b-2 border-gray-500 rounded-tl-lg rounded-tr-lg p-2")
+        h5(class="font-bold uppercase text-gray-600") Add/Update channel
+      div(class="p-5")
+        form(class="w-full m-4" method="POST" action="/admin/notifications/uploadChannel" encType="multipart/form-data")
+          div(class="flex -mx-3 mb-6")
+            div(class="w-1/2 px-3 mb-6 md:mb-0")
+              +formFile(null, "uploadFile")
+          div(class="w-1/2 px-3 mb-6 md:mb-0")
+            button(class="bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded") Add/Update Channel
+

--- a/views/admin/systemConfig.pug
+++ b/views/admin/systemConfig.pug
@@ -30,3 +30,6 @@ block content
           +tableRow('/admin/queues')
             +tableCell('Queues')
             +tableCell('Manage the system queues')
+          +tableRow('/admin/notifications/notificationChannels')
+            +tableCell('Notification Channels')
+            +tableCell('Manage the available notification channels')


### PR DESCRIPTION
This PR adds notification channel admin to the system. You can add/remove channels under the System Config menu option. Similar to tasks, the required fields in the channel config yaml file are `id` and `title`.

With this PR in place, we can start to work on the notification routing & provider tasks. As we implement them, we might have some adjustments here as well.

closes #536 