### PR TITLE
🐛 fixed bug removing task config

### DIFF
--- a/lib/cache/cache.js
+++ b/lib/cache/cache.js
@@ -64,7 +64,7 @@ async function fetchTaskConfig(id) {
  * @param {*} id
  */
 async function removeTaskConfig(id) {
-  await client.remove("stampede-" + id);
+  await client.remove("stampede-tasks-" + id);
   await client.removeMember("stampede-tasks", id);
 }
 
@@ -74,7 +74,7 @@ async function removeTaskConfig(id) {
 async function removeAllTasks() {
   const tasks = await client.fetchMembers("stampede-tasks");
   for (let index = 0; index < tasks.length; index++) {
-    await client.remove("stampede-" + tasks[index]);
+    await client.remove("stampede-tasks-" + tasks[index]);
   }
   await client.remove("stampede-tasks");
 }


### PR DESCRIPTION
This PR fixes a bug where the task config redis entry isn't deleted if the task is deleted. This doesn't cause any harm, but it does leave droppings in redis… 💩 

closes #538 
