### PR TITLE
🐛 Fixed error when viewing notification channel details

### DIFF
--- a/controllers/admin/notifications/channelConfig.js
+++ b/controllers/admin/notifications/channelConfig.js
@@ -28,7 +28,7 @@ async function handle(req, res, dependencies, owners) {
     isAdmin: req.validAdminSession,
     channelID: req.query.channelID,
     title: channelConfig.title,
-    config: channelConfig.config,
+    config: channelConfig.config != null ? channelConfig.config : [],
   });
 }
 


### PR DESCRIPTION
This PR fixes an error when viewing the notification channel details when the channel has no config parameters.

closes #545 
