### PR TITLE
✨ Add viewer for CLOC json artifacts

### DIFF
--- a/controllers/artifacts/viewCloc.js
+++ b/controllers/artifacts/viewCloc.js
@@ -1,0 +1,62 @@
+/**
+ * path this handler will serve
+ */
+function path() {
+  return "/artifacts/viewCloc";
+}
+
+/**
+ * handle buildDetails
+ * @param {*} req
+ * @param {*} res
+ * @param {*} dependencies
+ */
+async function handle(req, res, dependencies, owners) {
+  const taskRows = await dependencies.db.fetchTask(req.query.taskID);
+  const task = taskRows.rows[0];
+  const buildRows = await dependencies.db.fetchBuild(task.build_id);
+  const build = buildRows.rows[0];
+  const title = req.query.artifact;
+  const contents = await dependencies.db.fetchTaskContents(
+    req.query.taskID,
+    title
+  );
+
+  loc = [];
+  if (contents != null && contents.rows.length > 0) {
+    const rawData = contents.rows[0].contents;
+    Object.keys(rawData).forEach(function (key) {
+      if (key != "SUM" && key != "header") {
+        loc.push({
+          language: key,
+          code: rawData[key].code,
+          blank: rawData[key].blank,
+          nFiles: rawData[key].nFiles,
+          comment: rawData[key].comment,
+        });
+      }
+    });
+  }
+
+  const sortedLoc = loc.sort(function (a, b) {
+    if (a.code > b.code) {
+      return -1;
+    } else if (a.code < b.code) {
+      return 1;
+    } else {
+      return 0;
+    }
+  });
+
+  res.render(dependencies.viewsPath + "artifacts/viewCloc", {
+    owners: owners,
+    isAdmin: req.validAdminSession,
+    build: build,
+    task: task,
+    title: title,
+    loc: sortedLoc,
+  });
+}
+
+module.exports.path = path;
+module.exports.handle = handle;

--- a/controllers/history/buildDetails.js
+++ b/controllers/history/buildDetails.js
@@ -50,7 +50,11 @@ async function handle(req, res, dependencies, owners) {
     const artifactRows = await dependencies.db.fetchTaskArtifacts(task.task_id);
     if (artifactRows != null && artifactRows.rows != null) {
       for (let aindex = 0; aindex < artifactRows.rows.length; aindex++) {
-        artifacts.push(artifactRows.rows[aindex]);
+        const artifact = artifactRows.rows[aindex];
+        if (artifact.type == "cloc") {
+          artifact.url = `/artifacts/viewCloc?taskID=${task.task_id}&artifact=${artifact.title}`;
+        }
+        artifacts.push(artifact);
       }
     }
   }

--- a/controllers/history/buildTaskDetails.js
+++ b/controllers/history/buildTaskDetails.js
@@ -97,7 +97,11 @@ async function handle(req, res, dependencies, owners) {
     );
     if (artifactRows != null && artifactRows.rows != null) {
       for (let aindex = 0; aindex < artifactRows.rows.length; aindex++) {
-        artifacts.push(artifactRows.rows[aindex]);
+        const artifact = artifactRows.rows[aindex];
+        if (artifact.type == "cloc") {
+          artifact.url = `/artifacts/viewCloc?taskID=${task.task_id}&artifact=${artifact.title}`;
+        }
+        artifacts.push(artifact);
       }
     }
 

--- a/controllers/history/taskDetails.js
+++ b/controllers/history/taskDetails.js
@@ -111,7 +111,11 @@ async function handle(req, res, dependencies, owners) {
   );
   if (artifactRows != null && artifactRows.rows != null) {
     for (let aindex = 0; aindex < artifactRows.rows.length; aindex++) {
-      artifacts.push(artifactRows.rows[aindex]);
+      const artifact = artifactRows.rows[aindex];
+      if (artifact.type == "cloc") {
+        artifact.url = `/artifacts/viewCloc?taskID=${task.task_id}&artifact=${artifact.title}`;
+      }
+      artifacts.push(artifact);
     }
   }
 

--- a/controllers/repositories/buildDetails.js
+++ b/controllers/repositories/buildDetails.js
@@ -50,7 +50,11 @@ async function handle(req, res, dependencies, owners) {
     const artifactRows = await dependencies.db.fetchTaskArtifacts(task.task_id);
     if (artifactRows != null && artifactRows.rows != null) {
       for (let aindex = 0; aindex < artifactRows.rows.length; aindex++) {
-        artifacts.push(artifactRows.rows[aindex]);
+        const artifact = artifactRows.rows[aindex];
+        if (artifact.type == "cloc") {
+          artifact.url = `/artifacts/viewCloc?taskID=${task.task_id}&artifact=${artifact.title}`;
+        }
+        artifacts.push(artifact);
       }
     }
   }

--- a/controllers/repositories/taskDetails.js
+++ b/controllers/repositories/taskDetails.js
@@ -110,7 +110,11 @@ async function handle(req, res, dependencies, owners) {
   );
   if (artifactRows != null && artifactRows.rows != null) {
     for (let aindex = 0; aindex < artifactRows.rows.length; aindex++) {
-      artifacts.push(artifactRows.rows[aindex]);
+      const artifact = artifactRows.rows[aindex];
+      if (artifact.type == "cloc") {
+        artifact.url = `/artifacts/viewCloc?taskID=${task.task_id}&artifact=${artifact.title}`;
+      }
+      artifacts.push(artifact);
     }
   }
 

--- a/services/prCommentNotificationQueue.js
+++ b/services/prCommentNotificationQueue.js
@@ -34,7 +34,9 @@ function start(dependencies) {
  * shutdown
  */
 async function shutdown() {
-  await prCommentNotificationQueue.close();
+  if (prCommentNotificationQueue != null) {
+    await prCommentNotificationQueue.close();
+  }
 }
 
 module.exports.start = start;

--- a/services/slackNotificationQueue.js
+++ b/services/slackNotificationQueue.js
@@ -34,7 +34,9 @@ function start(dependencies) {
  * shutdown
  */
 async function shutdown() {
-  await slackNotificationQueue.close();
+  if (slackNotificationQueue != null) {
+    await slackNotificationQueue.close();
+  }
 }
 
 module.exports.start = start;

--- a/views/artifacts/viewCloc.pug
+++ b/views/artifacts/viewCloc.pug
@@ -1,0 +1,38 @@
+extends ../layout
+include ../components/titleBar
+include ../components/tableHeader
+include ../components/tableCell
+include ../components/tableRow
+include ../components/tableCellButton
+include ../components/infoCard
+include ../components/tableConclusionCell
+
+block content
+
+  +titleBar([{title: 'Repositories', href: `/repositories?owner=` + build.owner + `&=` + build.repository}, 
+      {title: build.owner + ' ' + build.repository, href: '/repositories/repositoryDetails?owner=' + build.owner + '&repository=' + build.repository},
+      {title: build.owner + '' + build.repository + ' #' + build.build, href: '/repositories/buildDetails?buildID=' + build.build_id},
+      {title: task.task, href: '/repositories/taskDetails?taskID=' + task.task_id},
+      {title: title}])
+  div(class="flex flex-wrap m-4")
+
+  div(class="w-full p-3")
+    div(class="bg-white border-transparent rounded-lg shadow-lg")
+        div(class="bg-gray-400 uppercase text-gray-800 border-b-2 border-gray-500 rounded-tl-lg rounded-tr-lg p-2")
+            h5(class="font-bold uppercase text-gray-600") Lines of Code
+        div(class="p-5")
+            table(class="table-auto w-full")
+                thead
+                    +tableHeader('Language')
+                    +tableHeader('Files')
+                    +tableHeader('Code Lines')
+                    +tableHeader('Blank Lines')
+                    +tableHeader('Comment Lines')
+                tbody
+                    each lang, i in loc
+                        +tableRow()
+                            +tableCell(lang.language)
+                            +tableCell(lang.nFiles)
+                            +tableCell(lang.code)
+                            +tableCell(lang.blank)
+                            +tableCell(lang.comment)

--- a/views/history/buildDetails.pug
+++ b/views/history/buildDetails.pug
@@ -88,5 +88,7 @@ block content
                       +tableCellButton("Download", artifact.url)
                     else if artifact.type == "link"
                       +tableCellButton("Open", artifact.url)
+                    else if artifact.type == "cloc"
+                      +tableCellButton("View", artifact.url)
 
 

--- a/views/history/buildTaskDetails.pug
+++ b/views/history/buildTaskDetails.pug
@@ -87,6 +87,8 @@ block content
                             +tableCellButton("Download", artifact.url)
                           else if artifact.type == "link"
                             +tableCellButton("Open", artifact.url)
+                          else if artifact.type == "cloc"
+                            +tableCellButton("View", artifact.url)
         
         +infoCard('Summary')
           div(id="task-result-summary")

--- a/views/history/taskDetails.pug
+++ b/views/history/taskDetails.pug
@@ -104,6 +104,8 @@ block content
                             +tableCellButton("Download", artifact.url)
                           else if artifact.type == "link"
                             +tableCellButton("Open", artifact.url)
+                          else if artifact.type == "cloc"
+                            +tableCellButton("View", artifact.url)
 
         +infoCard('Summary')
           div(id="task-result-summary")

--- a/views/repositories/buildDetails.pug
+++ b/views/repositories/buildDetails.pug
@@ -80,3 +80,5 @@ block content
                       +tableCellButton("Download", artifact.url)
                     else if artifact.type == "link"
                       +tableCellButton("Open", artifact.url)
+                    else if artifact.type == "cloc"
+                      +tableCellButton("View", artifact.url)

--- a/views/repositories/taskDetails.pug
+++ b/views/repositories/taskDetails.pug
@@ -85,6 +85,8 @@ block content
                             +tableCellButton("Download", artifact.url)
                           else if artifact.type == "link"
                             +tableCellButton("Open", artifact.url)
+                          else if artifact.type == "cloc"
+                            +tableCellButton("View", artifact.url)
 
         +infoCard('Summary')
           div(id="task-result-summary")


### PR DESCRIPTION
This PR adds a viewer in the UI for artifacts of type `cloc`. This is the first of many native viewers that will be created. This allows users to view data right in the Stampede UI and prevents the need to go into other systems, or download files. This viewer will show the output of the `cloc` command line app and show the number of lines of code per language.

closes #551 
