### PR TITLE
✨ Added artifact links to check summary

### DIFF
--- a/lib/taskUpdate.js
+++ b/lib/taskUpdate.js
@@ -17,6 +17,7 @@ async function handle(job, serverConf, cache, scm, db, logger) {
     const event = job;
 
     const taskID = event.taskID;
+    let artifactList = "";
 
     // Update task in the cache and send out notifications
     if (event.status === "completed") {
@@ -50,6 +51,28 @@ async function handle(job, serverConf, cache, scm, db, logger) {
               event.result.artifacts[aindex].contents,
               event.result.artifacts[aindex].metadata
             );
+
+            if (
+              event.result.artifacts[aindex].type == "download" ||
+              event.result.artifacts[aindex].type == "link"
+            ) {
+              artifactList +=
+                "- [" +
+                event.result.artifacts[aindex].title +
+                "](" +
+                event.result.artifacts[aindex].url +
+                ")\n";
+            } else if (event.result.artifacts[aindex].type == "cloc") {
+              artifactList +=
+                "- [" +
+                event.result.artifacts[aindex].title +
+                "](" +
+                serverConf.webURL +
+                "/artifacts/viewCloc?taskID=" +
+                event.taskID +
+                "&artifact=" +
+                event.result.artifacts[aindex].title;
+            }
           }
           event.result.artifacts = [];
         }
@@ -124,7 +147,7 @@ async function handle(job, serverConf, cache, scm, db, logger) {
       if (event.result.title != null) {
         update.output = {
           title: event.result.title,
-          summary: event.result.summary != null ? event.result.summary : "",
+          summary: summaryWithArtifactList(event.result.summary, artifactList),
           text: event.result.text != null ? event.result.text : "",
         };
       }
@@ -133,6 +156,14 @@ async function handle(job, serverConf, cache, scm, db, logger) {
     scm.updateCheck(event.owner, event.repository, serverConf, update);
   } catch (e) {
     logger.error(e);
+  }
+}
+
+function summaryWithArtifactList(summary, artifactList) {
+  if (summary != null) {
+    return summary + "\n" + artifactList;
+  } else {
+    return artifactList;
   }
 }
 

--- a/scm/testMode.js
+++ b/scm/testMode.js
@@ -95,6 +95,7 @@ async function getTagInfo(owner, repo, ref, serverConf) {
  */
 async function updateCheck(owner, repo, serverConf, update) {
   systemLogger.verbose("updateCheck");
+  systemLogger.verbose(JSON.stringify(update));
 }
 
 /**


### PR DESCRIPTION
This PR adds artifact links in the GitHub check summary. Now developers can get access directly to any artifact downloads or links directly from the GitHub check, without having to view it in the Stampede UI.

closes #550 
