### PR TITLE
🐛 fixed cloc artifact urls

### DIFF
--- a/lib/notificationChannels/prComment.js
+++ b/lib/notificationChannels/prComment.js
@@ -101,7 +101,8 @@ async function prepareBuildCompletedNotification(notification, dependencies) {
             "/artifacts/viewCloc?taskID=" +
             task.task_id +
             "&artifact=" +
-            encodeURI(artifactRows.rows[aindex].title);
+            encodeURI(artifactRows.rows[aindex].title) +
+            ")";
         }
       }
     }

--- a/lib/taskUpdate.js
+++ b/lib/taskUpdate.js
@@ -71,7 +71,8 @@ async function handle(job, serverConf, cache, scm, db, logger) {
                 "/artifacts/viewCloc?taskID=" +
                 event.taskID +
                 "&artifact=" +
-                encodeURI(event.result.artifacts[aindex].title);
+                encodeURI(event.result.artifacts[aindex].title) +
+                ")";
             }
           }
           event.result.artifacts = [];


### PR DESCRIPTION
This PR fixes a bug where the cloc artifact urls were missing an ending ).

closes #561 
