### PR TITLE
🐛 Allow notifications for repo builds

### DIFF
--- a/lib/repositoryBuild.js
+++ b/lib/repositoryBuild.js
@@ -33,6 +33,9 @@ async function execute(owner, repository, buildID, buildInfo, dependencies) {
       config: {},
       tasks: taskList,
     };
+    if (buildInfo.notifications != null) {
+      buildConfig.notifications = buildInfo.notifications;
+    }
 
     const repoConfig = {
       config: {},


### PR DESCRIPTION
This PR fixes an issue that was causing repository builds to not generate notifications. Now any notifications configured for the repo builds will be executed.

closes #564 
