### PR TITLE
🐛 fixed ordering of tasks in a build details

### DIFF
--- a/controllers/repositories/buildDetails.js
+++ b/controllers/repositories/buildDetails.js
@@ -72,7 +72,6 @@ async function handle(req, res, dependencies, owners) {
     }
   }
 
-  console.dir(artifacts);
   res.render(dependencies.viewsPath + "repositories/buildDetails", {
     owners: owners,
     isAdmin: req.validAdminSession,

--- a/lib/db.js
+++ b/lib/db.js
@@ -290,7 +290,8 @@ async function fetchBuild(buildID) {
  * @param {*} buildID
  */
 async function fetchBuildTasks(buildID) {
-  const query = "SELECT * from stampede.tasks where build_id = $1;";
+  const query =
+    "SELECT * from stampede.tasks where build_id = $1 order by queued_at;";
   return await execute("fetchBuildTasks", query, [buildID]);
 }
 


### PR DESCRIPTION
This PR fixes the list of tasks on any of the build details screen. This should order the tasks in the order they were started, putting any re-queued tasks at the end of the list.

closes #569 
