### PR TITLE
🐛 Fixed task status in pr comment

### DIFF
--- a/lib/notificationChannels/prComment.js
+++ b/lib/notificationChannels/prComment.js
@@ -145,7 +145,11 @@ async function prepareBuildCompletedNotification(notification, dependencies) {
     let message = ":scream: Oh no! Some of the stampede tasks have failed:\n\n";
 
     for (let index = 0; index < tasks.length; index++) {
-      message += "- :x: " + tasks[index].title + "\n";
+      if (task.conclusion == "failure") {
+        message += "- :x: " + tasks[index].title + "\n";
+      } else {
+        message += "- :white_check_mark: " + tasks[index].title + "\n";
+      }
     }
 
     message += "\n";


### PR DESCRIPTION
This PR fixes a bug that was causing the task status emoji to be incorrect in the PR comment.

closes #578 