### PR TITLE
✨ More info URL for slack & pr comment now configurable

### DIFF
--- a/bin/stampede-server.js
+++ b/bin/stampede-server.js
@@ -80,7 +80,9 @@ const conf = require("rc")("stampede", {
   enableApiDocs: false,
   // Notification channels
   handleSlackNotifications: "disabled",
+  slackNotificationMoreInfoURL: null,
   handlePRCommentNotifications: "disabled",
+  prCommentNotificationMoreInfoURL: null
 });
 
 // Configure winston logging

--- a/lib/notificationChannels/prComment.js
+++ b/lib/notificationChannels/prComment.js
@@ -38,6 +38,10 @@ async function sendNotification(notification, dependencies) {
 
 async function prepareBuildCompletedNotification(notification, dependencies) {
   // Ignore any builds that aren't PRs
+  let moreInfoURL = dependencies.serverConfig.webURL
+  if (dependencies.serverConfig.prCommentNotificationMoreInfoURL != null) {
+    moreInfoURL = dependencies.serverConfig.prCommentNotificationMoreInfoURL
+  }
 
   const build = await dependencies.db.fetchBuild(notification.build);
   const buildTasks = await dependencies.db.fetchBuildTasks(notification.build);
@@ -165,7 +169,7 @@ async function prepareBuildCompletedNotification(notification, dependencies) {
     message += "\n";
     message +=
       "[More Info...](" +
-      dependencies.serverConfig.webURL +
+      moreInfoURL +
       "/repositories/buildDetails?buildID=" +
       notification.build +
       ")";
@@ -188,7 +192,7 @@ async function prepareBuildCompletedNotification(notification, dependencies) {
 
     message +=
       "[More Info...](" +
-      dependencies.serverConfig.webURL +
+      moreInfoURL +
       "/repositories/buildDetails?buildID=" +
       notification.build +
       ")";

--- a/lib/notificationChannels/slack.js
+++ b/lib/notificationChannels/slack.js
@@ -59,6 +59,12 @@ async function prepareBuildStartedNotification(notification, dependencies) {
 }
 
 async function prepareBuildCompletedNotification(notification, dependencies) {
+
+  let moreInfoURL = dependencies.serverConfig.webURL
+  if (dependencies.serverConfig.slackNotificationMoreInfoURL != null) {
+    moreInfoURL = dependencies.serverConfig.slackNotificationMoreInfoURL
+  }
+
   const build = await dependencies.db.fetchBuild(notification.build);
   const buildTasks = await dependencies.db.fetchBuildTasks(notification.build);
   const buildDetails = build.rows.length > 0 ? build.rows[0] : {};
@@ -226,7 +232,7 @@ async function prepareBuildCompletedNotification(notification, dependencies) {
             message +
             " " +
             "*<" +
-            dependencies.serverConfig.webURL +
+            moreInfoURL +
             "/repositories/buildDetails?buildID=" +
             notification.build +
             "|More info...>* ",


### PR DESCRIPTION
This PR allows the admin to customize the url used in the PR comment or Slack notification. This can be used to direct users to the mobile app instead of the web, for example.

closes #593 
