### PR TITLE
♻️ Made metadata viewer admin only

### DIFF
--- a/views/history/buildDetails.pug
+++ b/views/history/buildDetails.pug
@@ -79,17 +79,19 @@ block content
       table(class="table-auto w-full")
         thead
           +tableHeader('Artifact')
-          +tableHeader('Info')
+          if isAdmin == true
+            +tableHeader('Info')
           +tableHeader('Action')
         tbody
             each artifact, i in artifacts
                 +tableRow(artifact.url)
                     +tableCell(artifact.title)
 
-                    if artifact.metadataurl != null
-                      +tableCellButton("Info", artifact.metadataurl)
-                    else
-                      +tableCell("")
+                    if isAdmin == true
+                      if artifact.metadataurl != null
+                        +tableCellButton("Info", artifact.metadataurl)
+                      else
+                        +tableCell("")
 
                     if artifact.type == "download"
                       +tableCellButton("Download", artifact.url)

--- a/views/history/buildTaskDetails.pug
+++ b/views/history/buildTaskDetails.pug
@@ -78,17 +78,19 @@ block content
             table(class="table-auto w-full")
               thead
                 +tableHeader('Artifact')
-                +tableHeader('Info')
+                if isAdmin == true
+                  +tableHeader('Info')
                 +tableHeader('Action')
               tbody
                   each artifact, i in artifacts
                       +tableRow(artifact.url)
                           +tableCell(artifact.title)
 
-                          if artifact.metadataurl != null
-                            +tableCellButton("Info", artifact.metadataurl)
-                          else
-                            +tableCell("")
+                          if isAdmin == true
+                            if artifact.metadataurl != null
+                              +tableCellButton("Info", artifact.metadataurl)
+                            else
+                              +tableCell("")
 
                           if artifact.type == "download"
                             +tableCellButton("Download", artifact.url)

--- a/views/history/taskDetails.pug
+++ b/views/history/taskDetails.pug
@@ -95,17 +95,19 @@ block content
             table(class="table-auto w-full")
               thead
                 +tableHeader('Artifact')
-                +tableHeader('Info')
+                if isAdmin == true
+                  +tableHeader('Info')
                 +tableHeader('Action')
               tbody
                   each artifact, i in artifacts
                       +tableRow(artifact.url)
                           +tableCell(artifact.title)
 
-                          if artifact.metadataurl != null
-                            +tableCellButton("Info", artifact.metadataurl)
-                          else
-                            +tableCell("")
+                          if isAdmin == true
+                            if artifact.metadataurl != null
+                              +tableCellButton("Info", artifact.metadataurl)
+                            else
+                              +tableCell("")
 
                           if artifact.type == "download"
                             +tableCellButton("Download", artifact.url)

--- a/views/repositories/buildDetails.pug
+++ b/views/repositories/buildDetails.pug
@@ -71,16 +71,19 @@ block content
       table(class="table-auto w-full")
         thead
           +tableHeader('Artifact')
-          +tableHeader('Info')
+          if isAdmin == true
+            +tableHeader('Info')
           +tableHeader('Action')
         tbody
             each artifact, i in artifacts
                 +tableRow(artifact.url)
                     +tableCell(artifact.title)
-                    if artifact.metadataurl != null
-                      +tableCellButton("Info", artifact.metadataurl)
-                    else
-                      +tableCell("")
+ 
+                    if isAdmin == true
+                      if artifact.metadataurl != null
+                        +tableCellButton("Info", artifact.metadataurl)
+                      else
+                        +tableCell("")
 
                     if artifact.type == "download"
                       +tableCellButton("Download", artifact.url)

--- a/views/repositories/taskDetails.pug
+++ b/views/repositories/taskDetails.pug
@@ -76,17 +76,19 @@ block content
             table(class="table-auto w-full")
               thead
                 +tableHeader('Artifact')
-                +tableHeader('Info')
+                if isAdmin == true
+                  +tableHeader('Info')
                 +tableHeader('Action')
               tbody
                   each artifact, i in artifacts
                       +tableRow(artifact.url)
                           +tableCell(artifact.title)
 
-                          if artifact.metadataurl != null
-                            +tableCellButton("Info", artifact.metadataurl)
-                          else
-                            +tableCell("")
+                          if isAdmin == true
+                            if artifact.metadataurl != null
+                              +tableCellButton("Info", artifact.metadataurl)
+                            else
+                              +tableCell("")
 
                           if artifact.type == "download"
                             +tableCellButton("Download", artifact.url)


### PR DESCRIPTION
This PR adjusts the Info button for metadata so that it is only visible for admins. These metadata items are meant to be underlying system details, not user meaningful.

closes #597 
