### PR TITLE
🐛 Fixed error when there are failing tasks in a pr comment

### DIFF
--- a/lib/notificationChannels/prComment.js
+++ b/lib/notificationChannels/prComment.js
@@ -159,7 +159,7 @@ async function prepareBuildCompletedNotification(notification, dependencies) {
     let message = ":scream: Oh no! Some of the stampede tasks have failed:\n\n";
 
     for (let index = 0; index < tasks.length; index++) {
-      if (task.conclusion == "failure") {
+      if (tasks[index].conclusion == "failure") {
         message += "- :x: " + tasks[index].title + "\n";
       } else {
         message += "- :white_check_mark: " + tasks[index].title + "\n";


### PR DESCRIPTION
This PR fixes an error that was happening on the server when a PR comment had failing tasks in it.

closes #614 
