### PR TITLE
🐛Fixed bug in filtering notifications

### DIFF
--- a/lib/notificationChannels/prComment.js
+++ b/lib/notificationChannels/prComment.js
@@ -12,6 +12,11 @@ async function sendNotification(notification, dependencies) {
     return null;
   }
 
+  const matches = await matchesFilter(notification, dependencies)
+  if (matches == false) {
+    return
+  }
+
   const owner = notification.payload.owner;
   const repository = notification.payload.repo;
   const parts = notification.payload.buildKey.split("-");
@@ -230,6 +235,29 @@ async function sendNotificationToPRComment(
     notification,
     dependencies.serverConfig
   );
+}
+
+async function matchesFilter(notification, dependencies) {
+  if (notification.filter === "all") {
+    return true
+  }
+
+  const buildTasks = await dependencies.db.fetchBuildTasks(notification.build);
+  let failedTasks = false
+  for (let index = 0; index < buildTasks.rows.length; index++) {
+    const task = buildTasks.rows[index];
+    if (task.conclusion == "failure") {
+      failedTasks = true;
+    }
+  }
+
+  if (notification.filter === "success" && failedTasks == false) {
+    return true
+  } else if (notification.filter === "failure" && failedTasks == true) {
+    return true
+  } else {
+    return false
+  }
 }
 
 module.exports.sendNotification = sendNotification;

--- a/lib/notificationChannels/slack.js
+++ b/lib/notificationChannels/slack.js
@@ -8,6 +8,11 @@ const LynnRequest = require("lynn-request");
  * @param {*} notification
  */
 async function sendNotification(notification, dependencies) {
+  const matchesFilter = await matchesFilter(notification, dependencies)
+  if (matchesFilter == false) {
+    return
+  }
+
   let notificationPayload = null;
   if (notification.notification === "buildStarted") {
     notificationPayload = await prepareBuildStartedNotification(
@@ -274,6 +279,28 @@ async function sendNotificationToSlackAPI(notification, config, dependencies) {
       resolve(result);
     });
   });
+}
+
+async function matchesFilter(notification, dependencies) {
+  if (notification.filter === "all") {
+    return true
+  }
+
+  const buildTasks = await dependencies.db.fetchBuildTasks(notification.build);
+  let failedTasks = false
+  for (let index = 0; index < buildTasks.rows.length; index++) {
+    if (task.conclusion == "failure") {
+      failedTasks = true;
+    }
+  }
+
+  if (notification.filter === "success" && failedTasks == false) {
+    return true
+  } else if (notification.filter === "failure" && failedTasks == true) {
+    return true
+  } else {
+    return false
+  }
 }
 
 module.exports.sendNotification = sendNotification;

--- a/lib/notificationChannels/slack.js
+++ b/lib/notificationChannels/slack.js
@@ -8,8 +8,8 @@ const LynnRequest = require("lynn-request");
  * @param {*} notification
  */
 async function sendNotification(notification, dependencies) {
-  const matchesFilter = await matchesFilter(notification, dependencies)
-  if (matchesFilter == false) {
+  const matches = await matchesFilter(notification, dependencies)
+  if (matches == false) {
     return
   }
 
@@ -289,6 +289,7 @@ async function matchesFilter(notification, dependencies) {
   const buildTasks = await dependencies.db.fetchBuildTasks(notification.build);
   let failedTasks = false
   for (let index = 0; index < buildTasks.rows.length; index++) {
+    const task = buildTasks.rows[index];
     if (task.conclusion == "failure") {
       failedTasks = true;
     }

--- a/services/notification.js
+++ b/services/notification.js
@@ -91,6 +91,8 @@ async function buildCompleted(build, payload, cache) {
     payload: payload,
   };
   await sendNotification(notification);
+  console.log("buildCompleted notification --->>>")
+  console.dir(notification)
 
   // If build has any notifications configured, send them
   if (

--- a/services/notification.js
+++ b/services/notification.js
@@ -66,13 +66,13 @@ async function buildStarted(build, payload, cache) {
         cache
       );
     }
-    if (notifications.start != null) {
+    if (notifications.started != null) {
       await sendToNotificationChannels(
         build,
         "buildStarted",
         "all",
         payload,
-        notifications.start,
+        notifications.started,
         cache
       );
     }

--- a/services/notification.js
+++ b/services/notification.js
@@ -91,8 +91,6 @@ async function buildCompleted(build, payload, cache) {
     payload: payload,
   };
   await sendNotification(notification);
-  console.log("buildCompleted notification --->>>")
-  console.dir(notification)
 
   // If build has any notifications configured, send them
   if (
@@ -116,27 +114,27 @@ async function buildCompleted(build, payload, cache) {
         "buildCompleted",
         "all",
         payload,
-        notifications.complete,
+        notifications.completed,
         cache
       );
     }
-    if (notifications.completed != null) {
+    if (notifications.completedSuccess != null) {
       await sendToNotificationChannels(
         build,
         "buildCompleted",
         "success",
         payload,
-        notifications.completeSuccess,
+        notifications.completedSuccess,
         cache
       );
     }
-    if (notifications.completed != null) {
+    if (notifications.completedFailure != null) {
       await sendToNotificationChannels(
         build,
         "buildCompleted",
         "failure",
         payload,
-        notifications.completeFailure,
+        notifications.completedFailure,
         cache
       );
     }


### PR DESCRIPTION
This PR fixes an issue where the filter for notifications wasn't working. Now `all`, `started`, `completed`, `completedSuccess` and `completedFailure` are working.

closes #616 
