### PR TITLE
♻️ Separate task and system queues in display and api

### DIFF
--- a/api/monitor/queueSummary.js
+++ b/api/monitor/queueSummary.js
@@ -26,14 +26,54 @@ async function handle(req, res, dependencies) {
   const queues = [];
 
   for (let index = 0; index < queueList.length; index++) {
-    const q = new Queue("stampede-" + queueList[index].id, redisConfig);
-    const stats = await q.getJobCounts();
+    let stats = await queueStats("stampede-" + queueList[index].id, redisConfig)
     queues.push({
       queue: queueList[index].id,
       stats: stats,
     });
   }
-  res.send(queues);
+
+  const systemQueues = []
+  let incomingStats = await queueStats(dependencies.serverConfig.incomingQueue, redisConfig)
+  systemQueues.push({
+    queue: dependencies.serverConfig.incomingQueue,
+    stats: incomingStats
+  })
+  let responseStats = await queueStats(dependencies.serverConfig.responseQueue, redisConfig)
+  systemQueues.push({
+    queue: dependencies.serverConfig.responseQueue,
+    stats: responseStats
+  })
+  if (dependencies.serverConfig.handleSlackNotifications === "enabled") {
+    let slackStats = await queueStats("slack-notifications", dependencies.redisConfig)
+    systemQueues.push({
+      queue: "slack-notifications",
+      stats: slackStats
+    })
+  }
+  if (dependencies.serverConfig.handlePRCommentNotifications === "enabled") {
+    let prCommentStats = await queueStats("prcomment-notifications", dependencies.redisConfig)
+    systemQueues.push({
+      queue: "prcomment-notifications",
+      stats: prCommentStats
+    })
+  }
+
+  res.send({ taskQueues: queues, systemQueues: systemQueues });
+}
+
+/**
+ * Collect queue stats
+ * @param {*} queue 
+ * @param {*} redisConfig 
+ */
+async function queueStats(queue, redisConfig) {
+  const q = new Queue(
+    "stampede-" + queue,
+    redisConfig
+  );
+  const stats = await q.getJobCounts();
+  return stats
 }
 
 /**

--- a/controllers/monitor/queues.js
+++ b/controllers/monitor/queues.js
@@ -14,27 +14,66 @@ function path() {
  * @param {*} dependencies
  */
 async function handle(req, res, dependencies, owners) {
+
+  // Fetch the task queues
   const queueList = await dependencies.cache.systemQueues.fetchSystemQueues();
   const queues = [];
-
   if (queueList != null) {
     for (let index = 0; index < queueList.length; index++) {
-      const q = new Queue(
-        "stampede-" + queueList[index].id,
-        dependencies.redisConfig
-      );
-      const stats = await q.getJobCounts();
+      let stats = await queueStats(queueList[index].id, dependencies.redisConfig)
       queues.push({
         queue: queueList[index].id,
         stats: stats,
       });
     }
   }
+
+  const systemQueues = []
+  let incomingStats = await queueStats(dependencies.serverConfig.incomingQueue, dependencies.redisConfig)
+  systemQueues.push({
+    queue: dependencies.serverConfig.incomingQueue,
+    stats: incomingStats
+  })
+  let responseStats = await queueStats(dependencies.serverConfig.responseQueue, dependencies.redisConfig)
+  systemQueues.push({
+    queue: dependencies.serverConfig.responseQueue,
+    stats: responseStats
+  })
+  if (dependencies.serverConfig.handleSlackNotifications === "enabled") {
+    let slackStats = await queueStats("slack-notifications", dependencies.redisConfig)
+    systemQueues.push({
+      queue: "slack-notifications",
+      stats: slackStats
+    })
+  }
+  if (dependencies.serverConfig.handlePRCommentNotifications === "enabled") {
+    let prCommentStats = await queueStats("prcomment-notifications", dependencies.redisConfig)
+    systemQueues.push({
+      queue: "prcomment-notifications",
+      stats: prCommentStats
+    })
+  }
+
   res.render(dependencies.viewsPath + "monitor/queues", {
     owners: owners,
     isAdmin: req.validAdminSession,
-    queues: queues,
+    taskQueues: queues,
+    systemQueues: systemQueues
   });
+}
+
+/**
+ * Collect queue stats
+ * @param {*} queue 
+ * @param {*} redisConfig 
+ */
+async function queueStats(queue, redisConfig) {
+  const q = new Queue(
+    "stampede-" + queue,
+    redisConfig
+  );
+  const stats = await q.getJobCounts();
+  return stats
 }
 
 module.exports.path = path;

--- a/controllers/monitor/queues.js
+++ b/controllers/monitor/queues.js
@@ -29,12 +29,14 @@ async function handle(req, res, dependencies, owners) {
   }
 
   const systemQueues = []
-  let incomingStats = await queueStats(dependencies.serverConfig.incomingQueue, dependencies.redisConfig)
+  let incomingStats = 
+    await queueStats(dependencies.serverConfig.incomingQueue, dependencies.redisConfig)
   systemQueues.push({
     queue: dependencies.serverConfig.incomingQueue,
     stats: incomingStats
   })
-  let responseStats = await queueStats(dependencies.serverConfig.responseQueue, dependencies.redisConfig)
+  let responseStats = 
+    await queueStats(dependencies.serverConfig.responseQueue, dependencies.redisConfig)
   systemQueues.push({
     queue: dependencies.serverConfig.responseQueue,
     stats: responseStats

--- a/views/monitor/queues.pug
+++ b/views/monitor/queues.pug
@@ -6,7 +6,7 @@ include ../components/tableRow
 
 block content
 
-  +titleBar([{title: 'Queues'}])
+  +titleBar([{title: 'Task Queues'}])
   div(class="flex flex-wrap m-4")
 
     table(class="table-auto w-full")
@@ -15,7 +15,21 @@ block content
           +tableHeader('Queue')
           +tableHeader('Tasks Waiting')
       tbody
-        each queue, i in queues
+        each queue, i in taskQueues
+          +tableRow()
+            +tableCell(queue.queue)
+            +tableCell(queue.stats.waiting.toString())
+
+  +titleBar([{title: 'System Queues'}])
+  div(class="flex flex-wrap m-4")
+
+    table(class="table-auto w-full")
+      thead
+        tr
+          +tableHeader('Queue')
+          +tableHeader('Waiting')
+      tbody
+        each queue, i in systemQueues
           +tableRow()
             +tableCell(queue.queue)
             +tableCell(queue.stats.waiting.toString())


### PR DESCRIPTION
This PR separates the display for task queues and system queues. Now the system queues will be displayed automatically so the admins don't have to define them in the queues.yaml file.

closes #624 