### PR TITLE
✨ Enabled a http post notification channel for queue summary updates

### DIFF
--- a/bin/stampede-server.js
+++ b/bin/stampede-server.js
@@ -85,6 +85,8 @@ const conf = require("rc")("stampede", {
   // Notification channels
   slackNotificationMoreInfoURL: null,
   prCommentNotificationMoreInfoURL: null,
+  // HTTP Notification feed
+  queueSummaryNotificationURL: null,
 });
 
 // Configure winston logging

--- a/lib/notificationChannels/httpPost.js
+++ b/lib/notificationChannels/httpPost.js
@@ -1,0 +1,39 @@
+"use strict";
+const url = require("url");
+const LynnRequest = require("lynn-request");
+
+/**
+ * sendNotification
+ * @param {*} notification
+ */
+async function sendNotification(notification, postURL, dependencies) {
+  if (postURL == null) {
+    return;
+  }
+
+  await sendHTTPPost(postURL, notification.notification.payload, dependencies);
+}
+
+async function sendHTTPPost(postURL, notification, dependencies) {
+  const fullURL = url.parse(postURL);
+  notification.id = new Date();
+
+  return new Promise((resolve) => {
+    const request = {};
+    request.options = {};
+    request.title = "sendMessage";
+    request.options.protocol = fullURL.protocol;
+    request.options.port = fullURL.port;
+    request.options.method = "POST";
+    request.options.host = fullURL.hostname;
+    request.options.path = fullURL.pathname;
+    request.options.body = notification;
+    const runner = new LynnRequest(request);
+    runner.execute(function (result) {
+      dependencies.logger.verbose("http notification sent to " + postURL);
+      resolve(result);
+    });
+  });
+}
+
+module.exports.sendNotification = sendNotification;

--- a/services/notificationChannelQueue.js
+++ b/services/notificationChannelQueue.js
@@ -3,6 +3,7 @@
 const taskQueue = require("../lib/taskQueue");
 const prComment = require("../lib/notificationChannels/prComment");
 const slack = require("../lib/notificationChannels/slack");
+const httpPost = require("../lib/notificationChannels/httpPost");
 
 let notificationQueue = null;
 
@@ -26,6 +27,12 @@ function start(dependencies) {
           prComment.sendNotification(job.data, dependencies);
         } else if (job.data.providerID === "slack-notifications") {
           slack.sendNotification(job.data, dependencies);
+        } else if (job.data.providerID === "queueHeartbeat") {
+          httpPost.sendNotification(
+            job.data,
+            dependencies.serverConfig.queueSummaryNotificationURL,
+            dependencies
+          );
         }
       } catch (e) {
         logger.error("Error handling pr comment notification: " + e);


### PR DESCRIPTION
This PR adds a http post notification channel for queue summary updates that can be enabled via config option: queueSummaryNotificationURL. Should be able to add more notifications to this channel in the future very easily.

closes #625 
