### PR TITLE
🐛 Closing queues that are opened for getting stats

### DIFF
--- a/api/monitor/queueSummary.js
+++ b/api/monitor/queueSummary.js
@@ -70,6 +70,7 @@ async function handle(req, res, dependencies) {
 async function queueStats(queue, redisConfig) {
   const q = new Queue("stampede-" + queue, redisConfig);
   const stats = await q.getJobCounts();
+  q.close();
   return stats;
 }
 

--- a/controllers/monitor/queues.js
+++ b/controllers/monitor/queues.js
@@ -72,6 +72,7 @@ async function handle(req, res, dependencies, owners) {
 async function queueStats(queue, redisConfig) {
   const q = new Queue("stampede-" + queue, redisConfig);
   const stats = await q.getJobCounts();
+  q.close();
   return stats;
 }
 

--- a/lib/queueHeartbeatHandler.js
+++ b/lib/queueHeartbeatHandler.js
@@ -67,6 +67,7 @@ async function handle(dependencies) {
 async function queueStats(queue, redisConfig) {
   const q = new Queue("stampede-" + queue, redisConfig);
   const stats = await q.getJobCounts();
+  q.close();
   return stats;
 }
 


### PR DESCRIPTION
This PR fixes a bug that was causing the queue heartbeat to fail due to no connections available.

closes #636 
