### PR TITLE
✨ Support installplist artifact types

### DIFF
--- a/api/repository/taskDetails.js
+++ b/api/repository/taskDetails.js
@@ -14,7 +14,7 @@ function path() {
  * @param {*} dependencies
  */
 async function handle(req, res, dependencies) {
-  const taskID = req.query.taskID
+  const taskID = req.query.taskID;
   const taskRows = await dependencies.db.fetchTask(taskID);
   const task = taskRows.rows[0];
 
@@ -128,14 +128,15 @@ async function handle(req, res, dependencies) {
           task.task_id +
           "&artifact=" +
           encodeURI(artifact.title);
-        } else if (artifact.type == "imagediff") {
-          artifact.url =
-            "/artifacts/viewImageGalleryDiff?taskID=" +
-            task.task_id +
-            "&artifact=" +
-            encodeURI(artifact.title);
-        } else if (artifact.type == "download") {
+      } else if (artifact.type == "imagediff") {
+        artifact.url =
+          "/artifacts/viewImageGalleryDiff?taskID=" +
+          task.task_id +
+          "&artifact=" +
+          encodeURI(artifact.title);
+      } else if (artifact.type == "download") {
       } else if (artifact.type == "link") {
+      } else if (artifact.type == "installplist") {
       } else {
         artifact.url =
           "/artifacts/viewUnknown?taskID=" +
@@ -154,7 +155,7 @@ async function handle(req, res, dependencies) {
     text: text,
     artifacts: artifacts,
     scmDetails: scmDetails,
-  })
+  });
 }
 
 /**

--- a/controllers/history/buildDetails.js
+++ b/controllers/history/buildDetails.js
@@ -77,6 +77,7 @@ async function handle(req, res, dependencies, owners) {
             encodeURI(artifact.title);
         } else if (artifact.type == "download") {
         } else if (artifact.type == "link") {
+        } else if (artifact.type == "installplist") {
         } else {
           artifact.url =
             "/artifacts/viewUnknown?taskID=" +

--- a/controllers/history/buildTaskDetails.js
+++ b/controllers/history/buildTaskDetails.js
@@ -124,6 +124,7 @@ async function handle(req, res, dependencies, owners) {
             encodeURI(artifact.title);
         } else if (artifact.type == "download") {
         } else if (artifact.type == "link") {
+        } else if (artifact.type == "installplist") {
         } else {
           artifact.url =
             "/artifacts/viewUnknown?taskID=" +

--- a/controllers/history/taskDetails.js
+++ b/controllers/history/taskDetails.js
@@ -138,6 +138,7 @@ async function handle(req, res, dependencies, owners) {
           encodeURI(artifact.title);
       } else if (artifact.type == "download") {
       } else if (artifact.type == "link") {
+      } else if (artifact.type == "installplist") {
       } else {
         artifact.url =
           "/artifacts/viewUnknown?taskID=" +

--- a/controllers/repositories/buildDetails.js
+++ b/controllers/repositories/buildDetails.js
@@ -78,6 +78,7 @@ async function handle(req, res, dependencies, owners) {
             encodeURI(artifact.title);
         } else if (artifact.type == "download") {
         } else if (artifact.type == "link") {
+        } else if (artifact.type == "installplist") {
         } else {
           artifact.url =
             "/artifacts/viewUnknown?taskID=" +

--- a/controllers/repositories/taskDetails.js
+++ b/controllers/repositories/taskDetails.js
@@ -137,6 +137,7 @@ async function handle(req, res, dependencies, owners) {
           encodeURI(artifact.title);
       } else if (artifact.type == "download") {
       } else if (artifact.type == "link") {
+      } else if (artifact.type == "installplist") {
       } else {
         artifact.url =
           "/artifacts/viewUnknown?taskID=" +

--- a/lib/notificationChannels/prComment.js
+++ b/lib/notificationChannels/prComment.js
@@ -12,9 +12,9 @@ async function sendNotification(notification, dependencies) {
     return null;
   }
 
-  const matches = await matchesFilter(notification, dependencies)
+  const matches = await matchesFilter(notification, dependencies);
   if (matches == false) {
-    return
+    return;
   }
 
   const owner = notification.payload.owner;
@@ -43,9 +43,9 @@ async function sendNotification(notification, dependencies) {
 
 async function prepareBuildCompletedNotification(notification, dependencies) {
   // Ignore any builds that aren't PRs
-  let moreInfoURL = dependencies.serverConfig.webURL
+  let moreInfoURL = dependencies.serverConfig.webURL;
   if (dependencies.serverConfig.prCommentNotificationMoreInfoURL != null) {
-    moreInfoURL = dependencies.serverConfig.prCommentNotificationMoreInfoURL
+    moreInfoURL = dependencies.serverConfig.prCommentNotificationMoreInfoURL;
   }
 
   const build = await dependencies.db.fetchBuild(notification.build);
@@ -103,7 +103,8 @@ async function prepareBuildCompletedNotification(notification, dependencies) {
 
         if (
           artifactRows.rows[aindex].type == "download" ||
-          artifactRows.rows[aindex].type == "link"
+          artifactRows.rows[aindex].type == "link" ||
+          artifactRows.rows[aindex].type == "installplist"
         ) {
           artifactList +=
             "- [" +
@@ -144,18 +145,18 @@ async function prepareBuildCompletedNotification(notification, dependencies) {
             "&artifact=" +
             encodeURI(artifactRows.rows[aindex].title) +
             ")\n";
-          } else if (artifactRows.rows[aindex].type == "imagediff") {
-            artifactList +=
-              "- [" +
-              artifactRows.rows[aindex].title +
-              "](" +
-              dependencies.serverConfig.webURL +
-              "/artifacts/viewImageGalleryDiff?taskID=" +
-              task.task_id +
-              "&artifact=" +
-              encodeURI(artifactRows.rows[aindex].title) +
-              ")\n";
-          } else {
+        } else if (artifactRows.rows[aindex].type == "imagediff") {
+          artifactList +=
+            "- [" +
+            artifactRows.rows[aindex].title +
+            "](" +
+            dependencies.serverConfig.webURL +
+            "/artifacts/viewImageGalleryDiff?taskID=" +
+            task.task_id +
+            "&artifact=" +
+            encodeURI(artifactRows.rows[aindex].title) +
+            ")\n";
+        } else {
           artifactList +=
             "- [" +
             artifactRows.rows[aindex].title +
@@ -239,11 +240,11 @@ async function sendNotificationToPRComment(
 
 async function matchesFilter(notification, dependencies) {
   if (notification.filter === "all") {
-    return true
+    return true;
   }
 
   const buildTasks = await dependencies.db.fetchBuildTasks(notification.build);
-  let failedTasks = false
+  let failedTasks = false;
   for (let index = 0; index < buildTasks.rows.length; index++) {
     const task = buildTasks.rows[index];
     if (task.conclusion == "failure") {
@@ -252,11 +253,11 @@ async function matchesFilter(notification, dependencies) {
   }
 
   if (notification.filter === "success" && failedTasks == false) {
-    return true
+    return true;
   } else if (notification.filter === "failure" && failedTasks == true) {
-    return true
+    return true;
   } else {
-    return false
+    return false;
   }
 }
 

--- a/lib/notificationChannels/slack.js
+++ b/lib/notificationChannels/slack.js
@@ -8,9 +8,9 @@ const LynnRequest = require("lynn-request");
  * @param {*} notification
  */
 async function sendNotification(notification, dependencies) {
-  const matches = await matchesFilter(notification, dependencies)
+  const matches = await matchesFilter(notification, dependencies);
   if (matches == false) {
-    return
+    return;
   }
 
   let notificationPayload = null;
@@ -64,10 +64,9 @@ async function prepareBuildStartedNotification(notification, dependencies) {
 }
 
 async function prepareBuildCompletedNotification(notification, dependencies) {
-
-  let moreInfoURL = dependencies.serverConfig.webURL
+  let moreInfoURL = dependencies.serverConfig.webURL;
   if (dependencies.serverConfig.slackNotificationMoreInfoURL != null) {
-    moreInfoURL = dependencies.serverConfig.slackNotificationMoreInfoURL
+    moreInfoURL = dependencies.serverConfig.slackNotificationMoreInfoURL;
   }
 
   const build = await dependencies.db.fetchBuild(notification.build);
@@ -124,7 +123,8 @@ async function prepareBuildCompletedNotification(notification, dependencies) {
         artifacts.push(artifactRows.rows[aindex]);
         if (
           artifactRows.rows[aindex].type == "download" ||
-          artifactRows.rows[aindex].type == "link"
+          artifactRows.rows[aindex].type == "link" ||
+          artifactRows.rows[aindex].type == "installplist"
         ) {
           artifactList +=
             "- *<" +
@@ -165,18 +165,18 @@ async function prepareBuildCompletedNotification(notification, dependencies) {
             "|" +
             artifactRows.rows[aindex].title +
             ">*\n";
-          } else if (artifactRows.rows[aindex].type == "imagediff") {
-            artifactList +=
-              "- *<" +
-              dependencies.serverConfig.webURL +
-              "/artifacts/viewImageGalleryDiff?taskID=" +
-              task.task_id +
-              "&artifact=" +
-              encodeURI(artifactRows.rows[aindex].title) +
-              "|" +
-              artifactRows.rows[aindex].title +
-              ">*\n";
-          } else {
+        } else if (artifactRows.rows[aindex].type == "imagediff") {
+          artifactList +=
+            "- *<" +
+            dependencies.serverConfig.webURL +
+            "/artifacts/viewImageGalleryDiff?taskID=" +
+            task.task_id +
+            "&artifact=" +
+            encodeURI(artifactRows.rows[aindex].title) +
+            "|" +
+            artifactRows.rows[aindex].title +
+            ">*\n";
+        } else {
           artifactList +=
             "- *<" +
             dependencies.serverConfig.webURL +
@@ -283,11 +283,11 @@ async function sendNotificationToSlackAPI(notification, config, dependencies) {
 
 async function matchesFilter(notification, dependencies) {
   if (notification.filter === "all") {
-    return true
+    return true;
   }
 
   const buildTasks = await dependencies.db.fetchBuildTasks(notification.build);
-  let failedTasks = false
+  let failedTasks = false;
   for (let index = 0; index < buildTasks.rows.length; index++) {
     const task = buildTasks.rows[index];
     if (task.conclusion == "failure") {
@@ -296,11 +296,11 @@ async function matchesFilter(notification, dependencies) {
   }
 
   if (notification.filter === "success" && failedTasks == false) {
-    return true
+    return true;
   } else if (notification.filter === "failure" && failedTasks == true) {
-    return true
+    return true;
   } else {
-    return false
+    return false;
   }
 }
 

--- a/lib/taskUpdate.js
+++ b/lib/taskUpdate.js
@@ -54,7 +54,8 @@ async function handle(job, serverConf, cache, scm, db, logger) {
 
             if (
               event.result.artifacts[aindex].type == "download" ||
-              event.result.artifacts[aindex].type == "link"
+              event.result.artifacts[aindex].type == "link" ||
+              event.result.artifacts[aindex].type == "installplist"
             ) {
               artifactList +=
                 "- [" +
@@ -95,18 +96,18 @@ async function handle(job, serverConf, cache, scm, db, logger) {
                 "&artifact=" +
                 encodeURI(event.result.artifacts[aindex].title) +
                 ")";
-              } else if (event.result.artifacts[aindex].type == "imagediff") {
-                artifactList +=
-                  "- [" +
-                  event.result.artifacts[aindex].title +
-                  "](" +
-                  serverConf.webURL +
-                  "/artifacts/viewImageGalleryDiff?taskID=" +
-                  event.taskID +
-                  "&artifact=" +
-                  encodeURI(event.result.artifacts[aindex].title) +
-                  ")";
-              } else {
+            } else if (event.result.artifacts[aindex].type == "imagediff") {
+              artifactList +=
+                "- [" +
+                event.result.artifacts[aindex].title +
+                "](" +
+                serverConf.webURL +
+                "/artifacts/viewImageGalleryDiff?taskID=" +
+                event.taskID +
+                "&artifact=" +
+                encodeURI(event.result.artifacts[aindex].title) +
+                ")";
+            } else {
               artifactList +=
                 "- [" +
                 event.result.artifacts[aindex].title +

--- a/views/history/buildDetails.pug
+++ b/views/history/buildDetails.pug
@@ -89,5 +89,7 @@ block content
                       +tableCellButton("Download", artifact.url)
                     else if artifact.type == "link"
                       +tableCellButton("Open", artifact.url)
+                    else if artifact.type == "installplist"
+                      +tableCellButton("Install", artifact.url)
                     else
                       +tableCellButton("View", artifact.url)

--- a/views/history/buildTaskDetails.pug
+++ b/views/history/buildTaskDetails.pug
@@ -88,6 +88,8 @@ block content
                             +tableCellButton("Download", artifact.url)
                           else if artifact.type == "link"
                             +tableCellButton("Open", artifact.url)
+                          else if artifact.type == "installplist"
+                            +tableCellButton("Install", artifact.url)
                           else
                             +tableCellButton("View", artifact.url)
         

--- a/views/history/taskDetails.pug
+++ b/views/history/taskDetails.pug
@@ -105,6 +105,8 @@ block content
                             +tableCellButton("Download", artifact.url)
                           else if artifact.type == "link"
                             +tableCellButton("Open", artifact.url)
+                          else if artifact.type == "installplist"
+                            +tableCellButton("Install", artifact.url)
                           else
                             +tableCellButton("View", artifact.url)
 

--- a/views/monitor/buildDetails.pug
+++ b/views/monitor/buildDetails.pug
@@ -77,3 +77,7 @@ block content
                       +tableCellButton("Download", artifact.url)
                     else if artifact.type == "link"
                       +tableCellButton("Open", artifact.url)
+                    else if artifact.type == "installplist"
+                      +tableCellButton("Install", artifact.url)
+                    else
+                      +tableCellButton("View", artifact.url)

--- a/views/monitor/buildTaskDetails.pug
+++ b/views/monitor/buildTaskDetails.pug
@@ -73,7 +73,11 @@ block content
                             +tableCellButton("Download", artifact.url)
                           else if artifact.type == "link"
                             +tableCellButton("Open", artifact.url)
-                        
+                          else if artifact.type == "installplist"
+                            +tableCellButton("Install", artifact.url)
+                          else
+                            +tableCellButton("View", artifact.url)
+                            
         +infoCard('Summary')
           div(id="task-result-summary")
           data(id="task-result-summary-data" hidden)

--- a/views/repositories/buildDetails.pug
+++ b/views/repositories/buildDetails.pug
@@ -81,5 +81,7 @@ block content
                       +tableCellButton("Download", artifact.url)
                     else if artifact.type == "link"
                       +tableCellButton("Open", artifact.url)
+                    else if artifact.type == "installplist"
+                      +tableCellButton("Install", artifact.url)
                     else
                       +tableCellButton("View", artifact.url)

--- a/views/repositories/taskDetails.pug
+++ b/views/repositories/taskDetails.pug
@@ -86,6 +86,8 @@ block content
                             +tableCellButton("Download", artifact.url)
                           else if artifact.type == "link"
                             +tableCellButton("Open", artifact.url)
+                          else if artifact.type == "installplist"
+                            +tableCellButton("Install", artifact.url)
                           else
                             +tableCellButton("View", artifact.url)
 


### PR DESCRIPTION
This PR modifies the server UI to show an `Install` button for any `installplist` artifact types. These artifacts can be used to install apps on iOS devices. This is mostly just a UI change since Stampede already supports artifacts of the `link` type. But adding the UI for `Install` makes it clear the link points to a plist file that can install the app on an iOS device.

closes #606 
