### PR TITLE
♻️Wrap install app plist url

### DIFF
--- a/api/repository/taskDetails.js
+++ b/api/repository/taskDetails.js
@@ -137,6 +137,9 @@ async function handle(req, res, dependencies) {
       } else if (artifact.type == "download") {
       } else if (artifact.type == "link") {
       } else if (artifact.type == "installplist") {
+        artifact.url =
+          "itms-services://?action=download-manifest&url=" +
+          encodeURI(artifact.url);
       } else {
         artifact.url =
           "/artifacts/viewUnknown?taskID=" +

--- a/api/repository/taskDetails.js
+++ b/api/repository/taskDetails.js
@@ -137,9 +137,6 @@ async function handle(req, res, dependencies) {
       } else if (artifact.type == "download") {
       } else if (artifact.type == "link") {
       } else if (artifact.type == "installplist") {
-        artifact.url =
-          "itms-services://?action=download-manifest&url=" +
-          encodeURI(artifact.url);
       } else {
         artifact.url =
           "/artifacts/viewUnknown?taskID=" +

--- a/controllers/history/buildDetails.js
+++ b/controllers/history/buildDetails.js
@@ -78,6 +78,9 @@ async function handle(req, res, dependencies, owners) {
         } else if (artifact.type == "download") {
         } else if (artifact.type == "link") {
         } else if (artifact.type == "installplist") {
+          artifact.url =
+            "itms-services://?action=download-manifest&url=" +
+            encodeURI(artifact.url);
         } else {
           artifact.url =
             "/artifacts/viewUnknown?taskID=" +

--- a/controllers/history/buildDetails.js
+++ b/controllers/history/buildDetails.js
@@ -80,7 +80,7 @@ async function handle(req, res, dependencies, owners) {
         } else if (artifact.type == "installplist") {
           artifact.url =
             "itms-services://?action=download-manifest&url=" +
-            encodeURI(artifact.url);
+            encodeURIComponent(artifact.url);
         } else {
           artifact.url =
             "/artifacts/viewUnknown?taskID=" +

--- a/controllers/history/buildTaskDetails.js
+++ b/controllers/history/buildTaskDetails.js
@@ -127,7 +127,7 @@ async function handle(req, res, dependencies, owners) {
         } else if (artifact.type == "installplist") {
           artifact.url =
             "itms-services://?action=download-manifest&url=" +
-            encodeURI(artifact.url);
+            encodeURIComponent(artifact.url);
         } else {
           artifact.url =
             "/artifacts/viewUnknown?taskID=" +

--- a/controllers/history/buildTaskDetails.js
+++ b/controllers/history/buildTaskDetails.js
@@ -125,6 +125,9 @@ async function handle(req, res, dependencies, owners) {
         } else if (artifact.type == "download") {
         } else if (artifact.type == "link") {
         } else if (artifact.type == "installplist") {
+          artifact.url =
+            "itms-services://?action=download-manifest&url=" +
+            encodeURI(artifact.url);
         } else {
           artifact.url =
             "/artifacts/viewUnknown?taskID=" +

--- a/controllers/history/taskDetails.js
+++ b/controllers/history/taskDetails.js
@@ -139,6 +139,9 @@ async function handle(req, res, dependencies, owners) {
       } else if (artifact.type == "download") {
       } else if (artifact.type == "link") {
       } else if (artifact.type == "installplist") {
+        artifact.url =
+          "itms-services://?action=download-manifest&url=" +
+          encodeURI(artifact.url);
       } else {
         artifact.url =
           "/artifacts/viewUnknown?taskID=" +

--- a/controllers/history/taskDetails.js
+++ b/controllers/history/taskDetails.js
@@ -141,7 +141,7 @@ async function handle(req, res, dependencies, owners) {
       } else if (artifact.type == "installplist") {
         artifact.url =
           "itms-services://?action=download-manifest&url=" +
-          encodeURI(artifact.url);
+          encodeURIComponent(artifact.url);
       } else {
         artifact.url =
           "/artifacts/viewUnknown?taskID=" +

--- a/controllers/repositories/buildDetails.js
+++ b/controllers/repositories/buildDetails.js
@@ -81,7 +81,7 @@ async function handle(req, res, dependencies, owners) {
         } else if (artifact.type == "installplist") {
           artifact.url =
             "itms-services://?action=download-manifest&url=" +
-            encodeURI(artifact.url);
+            encodeURIComponent(artifact.url);
         } else {
           artifact.url =
             "/artifacts/viewUnknown?taskID=" +

--- a/controllers/repositories/buildDetails.js
+++ b/controllers/repositories/buildDetails.js
@@ -79,6 +79,9 @@ async function handle(req, res, dependencies, owners) {
         } else if (artifact.type == "download") {
         } else if (artifact.type == "link") {
         } else if (artifact.type == "installplist") {
+          artifact.url =
+            "itms-services://?action=download-manifest&url=" +
+            encodeURI(artifact.url);
         } else {
           artifact.url =
             "/artifacts/viewUnknown?taskID=" +

--- a/controllers/repositories/taskDetails.js
+++ b/controllers/repositories/taskDetails.js
@@ -140,7 +140,7 @@ async function handle(req, res, dependencies, owners) {
       } else if (artifact.type == "installplist") {
         artifact.url =
           "itms-services://?action=download-manifest&url=" +
-          encodeURI(artifact.url);
+          encodeURIComponent(artifact.url);
       } else {
         artifact.url =
           "/artifacts/viewUnknown?taskID=" +

--- a/controllers/repositories/taskDetails.js
+++ b/controllers/repositories/taskDetails.js
@@ -138,6 +138,9 @@ async function handle(req, res, dependencies, owners) {
       } else if (artifact.type == "download") {
       } else if (artifact.type == "link") {
       } else if (artifact.type == "installplist") {
+        artifact.url =
+          "itms-services://?action=download-manifest&url=" +
+          encodeURI(artifact.url);
       } else {
         artifact.url =
           "/artifacts/viewUnknown?taskID=" +

--- a/lib/notificationChannels/prComment.js
+++ b/lib/notificationChannels/prComment.js
@@ -117,7 +117,7 @@ async function prepareBuildCompletedNotification(notification, dependencies) {
             artifactRows.rows[aindex].title +
             "](" +
             "itms-services://?action=download-manifest&url=" +
-            encodeURI(artifactRows.rows[aindex].url) +
+            encodeURIComponent(artifactRows.rows[aindex].url) +
             ")\n";
         } else if (artifactRows.rows[aindex].type == "cloc") {
           artifactList +=

--- a/lib/notificationChannels/prComment.js
+++ b/lib/notificationChannels/prComment.js
@@ -103,14 +103,21 @@ async function prepareBuildCompletedNotification(notification, dependencies) {
 
         if (
           artifactRows.rows[aindex].type == "download" ||
-          artifactRows.rows[aindex].type == "link" ||
-          artifactRows.rows[aindex].type == "installplist"
+          artifactRows.rows[aindex].type == "link"
         ) {
           artifactList +=
             "- [" +
             artifactRows.rows[aindex].title +
             "](" +
             artifactRows.rows[aindex].url +
+            ")\n";
+        } else if (artifactRows.rows[aindex].type == "installplist") {
+          artifactList +=
+            "- [" +
+            artifactRows.rows[aindex].title +
+            "](" +
+            "itms-services://?action=download-manifest&url=" +
+            encodeURI(artifactRows.rows[aindex].url) +
             ")\n";
         } else if (artifactRows.rows[aindex].type == "cloc") {
           artifactList +=

--- a/lib/notificationChannels/slack.js
+++ b/lib/notificationChannels/slack.js
@@ -135,7 +135,7 @@ async function prepareBuildCompletedNotification(notification, dependencies) {
           artifactList +=
             "- *<" +
             "itms-services://?action=download-manifest&url=" +
-            encodeURI(artifactRows.rows[aindex].url) +
+            encodeURIComponent(artifactRows.rows[aindex].url) +
             "|" +
             artifactRows.rows[aindex].title +
             ">*\n";

--- a/lib/notificationChannels/slack.js
+++ b/lib/notificationChannels/slack.js
@@ -123,12 +123,19 @@ async function prepareBuildCompletedNotification(notification, dependencies) {
         artifacts.push(artifactRows.rows[aindex]);
         if (
           artifactRows.rows[aindex].type == "download" ||
-          artifactRows.rows[aindex].type == "link" ||
-          artifactRows.rows[aindex].type == "installplist"
+          artifactRows.rows[aindex].type == "link"
         ) {
           artifactList +=
             "- *<" +
             artifactRows.rows[aindex].url +
+            "|" +
+            artifactRows.rows[aindex].title +
+            ">*\n";
+        } else if (artifactRows.rows[aindex].type == "installplist") {
+          artifactList +=
+            "- *<" +
+            "itms-services://?action=download-manifest&url=" +
+            encodeURI(artifactRows.rows[aindex].url) +
             "|" +
             artifactRows.rows[aindex].title +
             ">*\n";

--- a/lib/taskUpdate.js
+++ b/lib/taskUpdate.js
@@ -54,14 +54,21 @@ async function handle(job, serverConf, cache, scm, db, logger) {
 
             if (
               event.result.artifacts[aindex].type == "download" ||
-              event.result.artifacts[aindex].type == "link" ||
-              event.result.artifacts[aindex].type == "installplist"
+              event.result.artifacts[aindex].type == "link"
             ) {
               artifactList +=
                 "- [" +
                 event.result.artifacts[aindex].title +
                 "](" +
                 event.result.artifacts[aindex].url +
+                ")\n";
+            } else if (event.result.artifacts[aindex].type == "installplist") {
+              artifactList +=
+                "- [" +
+                event.result.artifacts[aindex].title +
+                "](" +
+                "itms-services://?action=download-manifest&url=" +
+                encodeURI(event.result.artifacts[aindex].url) +
                 ")\n";
             } else if (event.result.artifacts[aindex].type == "cloc") {
               artifactList +=

--- a/lib/taskUpdate.js
+++ b/lib/taskUpdate.js
@@ -68,7 +68,7 @@ async function handle(job, serverConf, cache, scm, db, logger) {
                 event.result.artifacts[aindex].title +
                 "](" +
                 "itms-services://?action=download-manifest&url=" +
-                encodeURI(event.result.artifacts[aindex].url) +
+                encodeURIComponent(event.result.artifacts[aindex].url) +
                 ")\n";
             } else if (event.result.artifacts[aindex].type == "cloc") {
               artifactList +=


### PR DESCRIPTION
This PR wraps the install app plist correctly so you can share the link provided in the Stampede UI and it should launch and install correctly on an iOS device.

closes #643 
