### PR TITLE
✨ Added dynamic task help page

### DIFF
--- a/controllers/help/taskHelp.js
+++ b/controllers/help/taskHelp.js
@@ -1,0 +1,80 @@
+require("pkginfo")(module);
+
+/**
+ * path this handler will serve
+ */
+function path() {
+  return "/help/taskHelp";
+}
+
+/**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return false;
+}
+
+/**
+ * handle tasks
+ * @param {*} req
+ * @param {*} res
+ * @param {*} dependencies
+ */
+async function handle(req, res, dependencies, owners) {
+  const taskDetails = await dependencies.cache.fetchTaskConfig(
+    req.query.taskID
+  );
+  const workerConfig = [];
+  if (taskDetails.worker != null) {
+    Object.keys(taskDetails.worker).forEach(function (key) {
+      workerConfig.push({ key: key, value: taskDetails.worker[key] });
+    });
+  }
+
+  let config = [];
+  if (taskDetails.config != null) {
+    for (let index = 0; index < taskDetails.config.length; index++) {
+      if (
+        taskDetails.config[index].adminParam == null ||
+        taskDetails.config[index].adminParam == false
+      ) {
+        if (taskDetails.config[index].allowedValues != null) {
+          const taskParam = taskDetails.config[index];
+          taskParam.description =
+            taskParam.description != null ? taskParam.description : "";
+          taskParam.description +=
+            "\nAllowed values: " + taskParam.allowedValues.join(",");
+          config.push(taskParam);
+        } else {
+          config.push(taskDetails.config[index]);
+        }
+      }
+    }
+  }
+
+  let example = "- id: " + req.query.taskID + "\n";
+  if (taskDetails.config != null) {
+    example += "  config:\n";
+    for (let index = 0; index < taskDetails.config.length; index++) {
+      if (
+        taskDetails.config[index].adminParam == null ||
+        taskDetails.config[index].adminParam == false
+      ) {
+        example +=
+          "    - " + taskDetails.config[index].key + ": <value goes here>\n";
+      }
+    }
+  }
+
+  res.render(dependencies.viewsPath + "help/taskHelp", {
+    owners: owners,
+    isAdmin: req.validAdminSession,
+    taskDetails: taskDetails,
+    config: config,
+    example: example,
+  });
+}
+
+module.exports.path = path;
+module.exports.handle = handle;
+module.exports.requiresAdmin = requiresAdmin;

--- a/controllers/help/tasks.js
+++ b/controllers/help/tasks.js
@@ -21,9 +21,24 @@ function requiresAdmin() {
  * @param {*} dependencies
  */
 async function handle(req, res, dependencies, owners) {
+  const taskList = await dependencies.cache.fetchTasks();
+  const sortedTasks = taskList.sort();
+  const tasks = [];
+  for (let index = 0; index < sortedTasks.length; index++) {
+    const taskDetails = await dependencies.cache.fetchTaskConfig(
+      sortedTasks[index]
+    );
+    if (taskDetails.adminTask == null || taskDetails.adminTask == false) {
+      tasks.push({
+        id: sortedTasks[index],
+        title: taskDetails.title,
+      });
+    }
+  }
   res.render(dependencies.viewsPath + "help/tasks", {
     owners: owners,
     isAdmin: req.validAdminSession,
+    tasks: tasks,
   });
 }
 

--- a/views/admin/taskConfig.pug
+++ b/views/admin/taskConfig.pug
@@ -32,6 +32,8 @@ block content
               each param, i in config
                 +tableRow()
                   +tableCell(param.key)
+                  if param.adminParam == true
+                    +tableCell("Admin Param")
 
     div(class="w-full md:w-1/2 xl:w-1/3 p-3")
       div(class="bg-white border-transparent rounded-lg shadow-lg")

--- a/views/help/taskHelp.pug
+++ b/views/help/taskHelp.pug
@@ -1,0 +1,46 @@
+extends ../layout
+
+include ../components/titleBar
+include ../components/tableHeader
+include ../components/tableCell
+include ../components/tableRow
+
+block content
+
+  +titleBar([{title: 'Tasks'}])
+  div(class="flex flex-wrap m-4")
+
+    div(class="w-full p-3")
+      div(class="bg-white border-transparent rounded-lg shadow-lg")
+        div(class="bg-gray-400 uppercase text-gray-800 border-b-2 border-gray-500 rounded-tl-lg rounded-tr-lg p-2")
+          h5(class="font-bold uppercase text-gray-600") Task Information
+        div(class="p-5")
+          table(class="table-auto w-full")
+            tbody
+              +tableRow()
+                +tableCell(taskDetails.id)
+              +tableRow()
+                +tableCell(taskDetails.title)
+              +tableRow()
+                +tableCell(taskDetails.description)
+
+    div(class="w-full p-3")
+      div(class="bg-white border-transparent rounded-lg shadow-lg")
+        div(class="bg-gray-400 uppercase text-gray-800 border-b-2 border-gray-500 rounded-tl-lg rounded-tr-lg p-2")
+          h5(class="font-bold uppercase text-gray-600") Config Parameters
+        div(class="p-5")
+          table(class="table-auto w-full")
+            tbody
+              each param, i in config
+                +tableRow()
+                  +tableCell(param.key)
+                  +tableCell(param.description)
+
+    div(class="w-full p-3")
+      div(class="bg-white border-transparent rounded-lg shadow-lg")
+        div(class="bg-gray-400 uppercase text-gray-800 border-b-2 border-gray-500 rounded-tl-lg rounded-tr-lg p-2")
+          h5(class="font-bold uppercase text-gray-600") .stampede.yaml example
+        div(class="p-5")
+          pre= example
+
+

--- a/views/help/tasks.pug
+++ b/views/help/tasks.pug
@@ -10,4 +10,26 @@ block content
   +titleBar([{title: 'Tasks'}])
   div(class="flex flex-wrap m-4")
 
-  h3= Task List
+    div
+      h3(class="text-l font-bold") Tasks
+
+      p. 
+        All builds in Stampede can be configured for as many tasks as are needed. Each
+        task can also be added to a build multiple times with different parameters to perform
+        slightly different operations (building different variants of a mobile app for example). Below
+        is the list of tasks that your system administrators have setup. Each task has a set 
+        of parameters that you can use to configure based on the details in your project.
+      br
+
+    div(class="flex flex-wrap m-4")
+      
+      table(class="table-auto w-full")
+        thead
+          tr
+            +tableHeader('Task ID')
+            +tableHeader('Title')
+        tbody
+          each task, i in tasks
+            +tableRow(`/help/taskHelp?taskID=` + task.id)
+              +tableCell(task.id)
+              +tableCell(task.title)


### PR DESCRIPTION
This PR adds a dynamic task list to the Help | Tasks screen. This is pulled from the task config that the admins have defined. Also included are new parameters available in the task config including a task description, parameter description, allowed list of values and if the parameter is an admin only parameter or not. Now the system admins can document the tasks and have that displayed for all users, including an example of how to add that task to your stampede file.

closes #510 
