### PR TITLE
✨ Now showing task params again, hiding adminParams if not admin

### DIFF
--- a/api/repository/taskDetails.js
+++ b/api/repository/taskDetails.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const taskDetail = require("../../lib/taskDetail");
+
 /**
  * The url path this handler will serve
  */
@@ -27,17 +29,12 @@ async function handle(req, res, dependencies) {
   let artifacts = [];
   if (detailsRows.rows.length > 0) {
     taskDetails = detailsRows.rows[0];
-    if (req.validAdminSession == true) {
-      Object.keys(
-        taskDetails.details.config != null ? taskDetails.details.config : {}
-      ).forEach(function (key) {
-        configValues.push({
-          key: key,
-          value: taskDetails.details.config[key].value,
-          source: taskDetails.details.config[key].source,
-        });
-      });
-    }
+    const taskConfig = await dependencies.cache.fetchTaskConfig(task.task);
+    configValues = await taskDetail.taskConfigValues(
+      taskDetails,
+      taskConfig,
+      req.validAdminSession
+    );
     summary =
       taskDetails.details.result != null &&
       taskDetails.details.result.summary != null

--- a/controllers/history/buildTaskDetails.js
+++ b/controllers/history/buildTaskDetails.js
@@ -1,4 +1,5 @@
 const prettyMilliseconds = require("pretty-ms");
+const taskDetail = require("../../lib/taskDetail");
 
 /**
  * path this handler will serve
@@ -20,23 +21,18 @@ async function handle(req, res, dependencies, owners) {
     const detailsRows = await dependencies.db.fetchTaskDetails(
       req.query.taskID
     );
-    const configValues = [];
+    let configValues = [];
     const scmDetails = [];
     let artifacts = [];
     let taskDetails = { details: {} };
     if (detailsRows.rows.length > 0) {
       taskDetails = detailsRows.rows[0];
-      if (req.validAdminSession == true) {
-        Object.keys(
-          taskDetails.details.config != null ? taskDetails.details.config : {}
-        ).forEach(function (key) {
-          configValues.push({
-            key: key,
-            value: taskDetails.details.config[key].value,
-            source: taskDetails.details.config[key].source,
-          });
-        });
-      }
+      const taskConfig = await dependencies.cache.fetchTaskConfig(task.task);
+      configValues = await taskDetail.taskConfigValues(
+        taskDetails,
+        taskConfig,
+        req.validAdminSession
+      );
       artifacts =
         taskDetails.details.result != null &&
         taskDetails.details.result.artifacts != null

--- a/controllers/monitor/buildTaskDetails.js
+++ b/controllers/monitor/buildTaskDetails.js
@@ -1,3 +1,5 @@
+const taskDetail = require("../../lib/taskDetail");
+
 /**
  * path this handler will serve
  */
@@ -19,18 +21,12 @@ async function handle(req, res, dependencies, owners) {
       req.query.taskID
     );
     const taskDetails = detailsRows.rows[0];
-    const configValues = [];
-    if (req.validAdminSession == true) {
-      Object.keys(
-        taskDetails.details.config != null ? taskDetails.details.config : {}
-      ).forEach(function (key) {
-        configValues.push({
-          key: key,
-          value: taskDetails.details.config[key].value,
-          source: taskDetails.details.config[key].source,
-        });
-      });
-    }
+    const taskConfig = await dependencies.cache.fetchTaskConfig(task.task);
+    const configValues = await taskDetail.taskConfigValues(
+      taskDetails,
+      taskConfig,
+      req.validAdminSession
+    );
     const buildRows = await dependencies.db.fetchBuild(task.build_id);
     const build = buildRows.rows[0];
     const summary =

--- a/lib/taskDetail.js
+++ b/lib/taskDetail.js
@@ -120,7 +120,10 @@ async function taskConfig(
       source = "systemOverride";
     }
     if (value != null) {
-      config[key] = { value: value, source: source };
+      config[key] = {
+        value: value,
+        source: source,
+      };
     } else {
       if (
         globalTasksConfig.config[index].required != null &&
@@ -159,8 +162,57 @@ async function taskWorkerConfig(taskID, cache) {
   return globalTaskConfig.worker;
 }
 
+/**
+ * taskConfigValues
+ * @param {*} taskDetails
+ * @param {*} taskConfig
+ * @param {*} validAdminSession
+ */
+async function taskConfigValues(taskDetails, taskConfig, validAdminSession) {
+  const configValues = [];
+  Object.keys(
+    taskDetails.details.config != null ? taskDetails.details.config : {}
+  ).forEach(function (key) {
+    const adminParam = isAdminParam(taskConfig, key);
+    if (
+      adminParam == false ||
+      (adminParam == true && validAdminSession == true)
+    ) {
+      configValues.push({
+        key: key,
+        value: taskDetails.details.config[key].value,
+        source: taskDetails.details.config[key].source,
+      });
+    }
+  });
+  return configValues;
+}
+
+/**
+ * Determine if a parameter is an adminParam or not
+ * @param {*} taskConfig
+ * @param {*} task
+ */
+function isAdminParam(taskConfig, task) {
+  if (taskConfig.config == null) {
+    return false;
+  }
+
+  for (let index = 0; index < taskConfig.config.length; index++) {
+    if (taskConfig.config[index].key == task) {
+      if (taskConfig.config[index].adminParam == null) {
+        return false;
+      } else {
+        return taskConfig.config[index].adminParam;
+      }
+    }
+  }
+  return false;
+}
+
 module.exports.isValidTask = isValidTask;
 module.exports.taskTitle = taskTitle;
 module.exports.taskConfig = taskConfig;
 module.exports.taskQueue = taskQueue;
 module.exports.taskWorkerConfig = taskWorkerConfig;
+module.exports.taskConfigValues = taskConfigValues;


### PR DESCRIPTION
This PR brings back the display of task config params to the task details screen. Now users can see the params that are associated with a particular task execution. If there are task params marked `adminParam` then these will not be displayed unless you are logged in as an admin.

closes #653 
