### PR TITLE
✨ Added validation based on allowedValues config in task definition

### DIFF
--- a/lib/task.js
+++ b/lib/task.js
@@ -267,9 +267,25 @@ async function startTask(
     // Ensure we have all the required parameters. If we are missing any then fail the task before
     // we add it to a queue
     let validParams = true;
+    let invalidMessage = "";
     Object.keys(taskConfig).forEach(function (key) {
-      if (taskConfig[key].source === "missing-required") {
+      if (
+        taskConfig[key].source === "missing-required" ||
+        taskConfig[key].source === "not-in-allowed-values"
+      ) {
         validParams = false;
+      }
+
+      if (taskConfig[key].source === "missing-required") {
+        invalidMessage += "Missing required param: " + key + "\n ";
+      }
+      if (taskConfig[key].source === "not-in-allowed-values") {
+        invalidMessage +=
+          "Param " +
+          key +
+          " has a value of " +
+          taskConfig[key].value +
+          " which is not in the allowed values\n ";
       }
     });
 
@@ -334,7 +350,7 @@ async function startTask(
       taskDetails.status = "completed";
       taskDetails.result = {
         conclusion: "failure",
-        summary: "Missing required task parameters",
+        summary: invalidMessage,
       };
       taskDetails.stats.finishedAt = new Date();
       taskUpdate.handle(taskDetails, serverConf, cache, scm, db, logger);

--- a/lib/taskDetail.js
+++ b/lib/taskDetail.js
@@ -120,10 +120,25 @@ async function taskConfig(
       source = "systemOverride";
     }
     if (value != null) {
-      config[key] = {
-        value: value,
-        source: source,
-      };
+      if (globalTasksConfig.config[index].allowedValues != null) {
+        try {
+          if (globalTasksConfig.config[index].allowedValues.includes(value)) {
+            config[key] = {
+              value: value,
+              source: source,
+            };
+          } else {
+            config[key] = { value: value, source: "not-in-allowed-values" };
+          }
+        } catch (e) {
+          config[key] = { value: "", source: "not-in-allowed-values" };
+        }
+      } else {
+        config[key] = {
+          value: value,
+          source: source,
+        };
+      }
     } else {
       if (
         globalTasksConfig.config[index].required != null &&


### PR DESCRIPTION
This PR adds validation to a task param values based on the `allowedValues` option inside the task definition. So if a task param is configured with some `allowedValues`, but then the task execution doesn't include a value from the list, the task immediately fails. This is similar to how required values work.

closes #652 
