### PR TITLE
♻️ Adjusted worker timeout mechanism to remember recent workers

### DIFF
--- a/bin/stampede-server.js
+++ b/bin/stampede-server.js
@@ -87,6 +87,8 @@ const conf = require("rc")("stampede", {
   prCommentNotificationMoreInfoURL: null,
   // HTTP Notification feed
   queueSummaryNotificationURL: null,
+  // Worker notes
+  workerHeartbeatTimeout: 3600,
 });
 
 // Configure winston logging

--- a/lib/cache/cache.js
+++ b/lib/cache/cache.js
@@ -12,6 +12,8 @@ const repositoryBuilds = require("./repositoryBuilds");
 const admin = require("./admin");
 const notifications = require("./notifications");
 
+let workerHeartbeatTimeout = 35;
+
 // Public functions
 
 // General
@@ -30,6 +32,7 @@ function startCache(conf) {
   repositoryBuilds.setClient(client);
   admin.setClient(client);
   notifications.setClient(client);
+  workerHeartbeatTimeout = conf.workerHeartbeatTimeout;
 }
 
 /**
@@ -335,8 +338,15 @@ async function removePendingList(parentTaskID) {
  * @param {*} heartbeat
  */
 async function storeWorkerHeartbeat(heartbeat) {
-  await client.add("stampede-activeworkers", heartbeat.workerID);
-  await client.store("stampede-worker-" + heartbeat.workerID, heartbeat, 35);
+  await client.add(
+    "stampede-activeworkers",
+    heartbeat.node + heartbeat.workerName
+  );
+  await client.store(
+    "stampede-worker-" + heartbeat.node + heartbeat.workerName,
+    heartbeat,
+    workerHeartbeatTimeout
+  );
 }
 
 /**

--- a/views/monitor/workers.pug
+++ b/views/monitor/workers.pug
@@ -20,7 +20,10 @@ block content
       tbody
         each worker, i in workers
           +tableRow(`/monitor/workerDetails?workerID=` + worker.workerID)
-            +tableCell(worker.node)
+            if new Date() - Date.parse(worker.timestamp) > 30000
+              +tableCell("❌ " + worker.node)
+            else
+              +tableCell("✅ " + worker.node)
             +tableCell(worker.workerName)
             +tableCell(worker.status)
             +tableCell(worker.taskQueue)


### PR DESCRIPTION
This PR changes the worker heartbeat storage to allow for extending the time the worker heartbeat is kept in memory. This allows the worker status screen to display a status if the worker hasn't reported in 30 seconds. By default the missing worker will show in the portal for an hour, but then will drop off the list.

closes #621 
