### PR TITLE
♻️ Removed archive filter for branch and release builds on repo details

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -910,9 +910,9 @@ async function fetchBuildKeys(owner, repository, source) {
       "SELECT DISTINCT build_key from stampede.builds WHERE \
     owner = $1 AND \
     repository = $2 AND \
-    source = $3 AND \
-    archived is null \
-    ORDER BY build_key";
+    source = $3 \
+    ORDER BY build_key \
+    LIMIT 25";
   } else if (source === "pull-request") {
     query =
       "SELECT DISTINCT build_key from stampede.builds WHERE \
@@ -927,10 +927,9 @@ async function fetchBuildKeys(owner, repository, source) {
       "SELECT build_key FROM stampede.builds \
         WHERE owner = $1 AND \
         repository = $2 AND \
-        source = $3 AND \
-        archived is null \
+        source = $3 \
         ORDER BY started_at DESC \
-        LIMIT 10";
+        LIMIT 25";
   }
   return await execute("fetchBuildKeys", query, [owner, repository, source]);
 }


### PR DESCRIPTION
This PR changes the filter on the repository details queries to return archived builds under branches and releases. For infrequently used repos we want to at least show something under these, even if the builds are old and archived.

closes #670 
