### PR TITLE
✨ Server now stores incoming github events for main source events

### DIFF
--- a/bin/stampede-server.js
+++ b/bin/stampede-server.js
@@ -89,6 +89,8 @@ const conf = require("rc")("stampede", {
   queueSummaryNotificationURL: null,
   // Worker notes
   workerHeartbeatTimeout: 3600,
+  // Repository event cache limit
+  repoEventLimit: 10,
 });
 
 // Configure winston logging

--- a/lib/cache/cache.js
+++ b/lib/cache/cache.js
@@ -13,6 +13,7 @@ const admin = require("./admin");
 const notifications = require("./notifications");
 
 let workerHeartbeatTimeout = 35;
+let repoEventLimit = 10;
 
 // Public functions
 
@@ -33,6 +34,7 @@ function startCache(conf) {
   admin.setClient(client);
   notifications.setClient(client);
   workerHeartbeatTimeout = conf.workerHeartbeatTimeout;
+  repoEventLimit = conf.repoEventLimit;
 }
 
 /**
@@ -390,6 +392,35 @@ async function addOwner(owner) {
   await client.add("stampede-owners", owner);
 }
 
+/**
+ * storeRepoEvent
+ * @param {*} owner
+ * @param {*} repo
+ * @param {*} event
+ */
+async function storeRepoEvent(owner, repo, event) {
+  // Ignore if our repoEventLimit is 0
+  if (repoEventLimit > 0) {
+    await client.pushItem(
+      "stampede-" + owner + "-" + repo + "-events",
+      event,
+      repoEventLimit
+    );
+  }
+}
+
+/**
+ * fetchRepoEvents
+ * @param {*} owner
+ * @param {*} repo
+ */
+async function fetchRepoEvents(owner, repo) {
+  const events = await cache.fetchItems(
+    "stampede-" + owner + "-" + repo + "-events"
+  );
+  return events;
+}
+
 // Private functions
 
 // General
@@ -453,3 +484,7 @@ module.exports.systemQueues = systemQueues;
 module.exports.repositoryBuilds = repositoryBuilds;
 module.exports.admin = admin;
 module.exports.notifications = notifications;
+
+// Events
+module.exports.storeRepoEvent = storeRepoEvent;
+module.exports.fetchRepoEvents = fetchRepoEvents;

--- a/lib/cache/cacheClient.js
+++ b/lib/cache/cacheClient.js
@@ -163,6 +163,43 @@ async function fetchMembers(key, defaultValue) {
 }
 
 /**
+ * pushItem
+ * Push an item on a list, but limit the total number of items in the list
+ * @param {*} key
+ * @param {*} value
+ * @param {*} limit
+ */
+async function pushItem(key, value, limit) {
+  try {
+    const count = await client.lpush(key, JSON.stringify(value));
+    if (count > limit) {
+      const result = await client.ltrim(key, 0, limit - 1);
+    }
+  } catch (e) {
+    console.error("Error pushing item to list: " + key + " " + e);
+  }
+}
+
+/**
+ * fetchItems
+ * Fetch all the items from a list, returning an array
+ * @param {*} key
+ */
+async function fetchItems(key) {
+  const found = [];
+  try {
+    const count = await client.llen(key);
+    for (let index = 0; index < count; index++) {
+      const item = await client.lindex(key, index);
+      found.push(JSON.parse(item));
+    }
+  } catch (e) {
+    console.error("Error pushing item to list: " + key + " " + e);
+  }
+  return found;
+}
+
+/**
  * quit
  */
 async function quit() {
@@ -178,3 +215,5 @@ module.exports.removeMember = removeMember;
 module.exports.fetch = fetch;
 module.exports.fetchMembers = fetchMembers;
 module.exports.quit = quit;
+module.exports.pushItem = pushItem;
+module.exports.fetchItems = fetchItems;

--- a/scm/events/pullRequest.js
+++ b/scm/events/pullRequest.js
@@ -19,6 +19,10 @@ async function handle(body, dependencies) {
   }
   notification.repositoryEventReceived("pull_request", event);
 
+  dependencies.cache.storeRepoEvent(event.owner, event.repo, {
+    source: "pull-request",
+    body: body,
+  });
   await dependencies.db.storeRepository(event.owner, event.repo);
 
   if (

--- a/scm/events/push.js
+++ b/scm/events/push.js
@@ -17,6 +17,10 @@ async function handle(body, dependencies) {
   dependencies.logger.info("PushEvent:");
   notification.repositoryEventReceived("push", event);
 
+  dependencies.cache.storeRepoEvent(event.owner, event.repo, {
+    source: "branch-push",
+    body: body,
+  });
   await dependencies.db.storeRepository(event.owner, event.repo);
 
   if (event.deleted === true) {

--- a/scm/events/release.js
+++ b/scm/events/release.js
@@ -17,6 +17,10 @@ async function handle(body, dependencies) {
   dependencies.logger.info("ReleaseEvent:");
   notification.repositoryEventReceived("release", event);
 
+  dependencies.cache.storeRepoEvent(event.owner, event.repo, {
+    source: "release",
+    body: body,
+  });
   await dependencies.db.storeRepository(event.owner, event.repo);
 
   if (event.action !== "published") {


### PR DESCRIPTION
This PR updates the server to store incoming GitHub events in the Redis cache. By default the system will store the last 10 events that are either for a pull request, branch push or release. The check suite/run events are not being stored right now since those are more internal to GitHub <-> Stampede communication. By storing these main events that are hard to recreate, we can build a UI inside Stampede where the Admins can see these events and re-trigger them. This is better than the GitHub UI for doing this since it doesn't break things up by repo. This is the first of several PRs to fully implement the functionality. This PR simply stores the incoming events.

Use the `repoEventLimit` server configuration parameter to adjust the number of events. If you set this value to 0, no events will be stored.

closes #169 
