### PR TITLE
✨ Added a screen for viewing repo events

### DIFF
--- a/controllers/admin/viewRepoEventDetails.js
+++ b/controllers/admin/viewRepoEventDetails.js
@@ -1,0 +1,41 @@
+/**
+ * path this handler will serve
+ */
+function path() {
+  return "/admin/viewRepoEventDetails";
+}
+
+/**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
+ * handle index
+ * @param {*} req
+ * @param {*} res
+ * @param {*} dependencies
+ */
+async function handle(req, res, dependencies, owners) {
+  const owner = req.query.owner;
+  const repository = req.query.repository;
+  const events = await dependencies.cache.fetchRepoEvents(owner, repository);
+  let body = "";
+  if (req.query.index >= 0 && req.query.index < events.length) {
+    body = JSON.stringify(events[req.query.index].body, null, 2);
+  }
+
+  res.render(dependencies.viewsPath + "admin/viewRepoEventDetails", {
+    owners: owners,
+    isAdmin: req.validAdminSession,
+    owner: owner,
+    repository: repository,
+    body: body,
+  });
+}
+
+module.exports.path = path;
+module.exports.requiresAdmin = requiresAdmin;
+module.exports.handle = handle;

--- a/controllers/admin/viewRepoEvents.js
+++ b/controllers/admin/viewRepoEvents.js
@@ -1,0 +1,37 @@
+/**
+ * path this handler will serve
+ */
+function path() {
+  return "/admin/viewRepoEvents";
+}
+
+/**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
+ * handle index
+ * @param {*} req
+ * @param {*} res
+ * @param {*} dependencies
+ */
+async function handle(req, res, dependencies, owners) {
+  const owner = req.query.owner;
+  const repository = req.query.repository;
+  const events = await dependencies.cache.fetchRepoEvents(owner, repository);
+
+  res.render(dependencies.viewsPath + "admin/viewRepoEvents", {
+    owners: owners,
+    isAdmin: req.validAdminSession,
+    owner: owner,
+    repository: repository,
+    events: events,
+  });
+}
+
+module.exports.path = path;
+module.exports.requiresAdmin = requiresAdmin;
+module.exports.handle = handle;

--- a/lib/cache/cache.js
+++ b/lib/cache/cache.js
@@ -415,7 +415,7 @@ async function storeRepoEvent(owner, repo, event) {
  * @param {*} repo
  */
 async function fetchRepoEvents(owner, repo) {
-  const events = await cache.fetchItems(
+  const events = await client.fetchItems(
     "stampede-" + owner + "-" + repo + "-events"
   );
   return events;

--- a/scm/events/pullRequest.js
+++ b/scm/events/pullRequest.js
@@ -21,6 +21,7 @@ async function handle(body, dependencies) {
 
   dependencies.cache.storeRepoEvent(event.owner, event.repo, {
     source: "pull-request",
+    timestamp: new Date(),
     body: body,
   });
   await dependencies.db.storeRepository(event.owner, event.repo);

--- a/scm/events/push.js
+++ b/scm/events/push.js
@@ -19,6 +19,7 @@ async function handle(body, dependencies) {
 
   dependencies.cache.storeRepoEvent(event.owner, event.repo, {
     source: "branch-push",
+    timestamp: new Date(),
     body: body,
   });
   await dependencies.db.storeRepository(event.owner, event.repo);

--- a/scm/events/release.js
+++ b/scm/events/release.js
@@ -19,6 +19,7 @@ async function handle(body, dependencies) {
 
   dependencies.cache.storeRepoEvent(event.owner, event.repo, {
     source: "release",
+    timestamp: new Date(),
     body: body,
   });
   await dependencies.db.storeRepository(event.owner, event.repo);

--- a/views/admin/repositoryAdmin.pug
+++ b/views/admin/repositoryAdmin.pug
@@ -48,6 +48,10 @@ block content
                 +tableCell('Manually Execute Task')
                 +tableCell('')
                 +tableCellButton("Start", `/admin/executeTaskSelection?owner=` + owner + `&repository=` + repository)
+              +tableRow()
+                +tableCell('SCM Events')
+                +tableCell('')
+                +tableCellButton("View", `/admin/viewRepoEvents?owner=` + owner + `&repository=` + repository)
 
   div(class="w-full p-3")
       div(class="bg-white border-transparent rounded-lg shadow-lg")

--- a/views/admin/viewRepoEventDetails.pug
+++ b/views/admin/viewRepoEventDetails.pug
@@ -1,0 +1,20 @@
+extends ../layout
+
+include ../components/titleBar
+include ../components/tableHeader
+include ../components/tableCell
+include ../components/tableRow
+include ../components/formFile
+include ../components/formHidden
+
+block content
+
+	+titleBar([{title: 'Repositories', href: '/admin/repositories'},
+	{title: owner + ' ' + repository, href: '/admin/repositoryAdmin?owner=' + owner + '&repository=' + repository},
+	{title: 'Repository SCM Events', href: '/admin/viewRepoEvents?owner=' + owner + '&repository=' + repository},
+	{title: 'Event Details'}])
+
+	div(class="flex flex-wrap m-4")
+	div(class="flex flex-wrap m-4")
+
+		pre= body

--- a/views/admin/viewRepoEvents.pug
+++ b/views/admin/viewRepoEvents.pug
@@ -1,0 +1,28 @@
+extends ../layout
+
+include ../components/titleBar
+include ../components/tableHeader
+include ../components/tableCell
+include ../components/tableRow
+include ../components/formFile
+include ../components/formHidden
+
+block content
+
+	+titleBar([{title: 'Repositories', href: '/admin/repositories'},
+	{title: owner + ' ' + repository, href: '/admin/repositoryAdmin?owner=' + owner + '&repository=' + repository},
+	{title: 'Repository SCM Events'}])
+		
+	div(class="flex flex-wrap m-4")
+	div(class="flex flex-wrap m-4")
+
+		table(class="table-auto w-full")
+			thead
+				tr
+					+tableHeader('Source')
+					+tableHeader('Timestamp')
+			tbody
+				each event, i in events
+					+tableRow('/admin/viewRepoEventDetails?owner=' + owner + '&repository=' + repository + '&index=' + i)
+						+tableCell(event.source)
+						+tableCell(event.timestamp)


### PR DESCRIPTION
This PR adds a screen to the Admin section under the Repository details screen which allows for viewing the SCM events for that repo. This will show the latest events that have been received. The number of events by default is 10, but you can configure this with a server parameter.

closes #382 
