### PR TITLE
✨ Added execute button for scm events

### DIFF
--- a/controllers/admin/executeRepoEvent.js
+++ b/controllers/admin/executeRepoEvent.js
@@ -1,0 +1,60 @@
+const pullRequestEvent = require("../../scm/events/pullRequest.js");
+const pushEvent = require("../../scm/events/push.js");
+const releaseEvent = require("../../scm/events/release.js");
+
+/**
+ * path this handler will serve
+ */
+function path() {
+  return "/admin/executeRepoEvent";
+}
+
+/**
+ * http method this handler will serve
+ */
+function method() {
+  return "post";
+}
+
+/**
+ * handle executeTaskSelection
+ * @param {*} req
+ * @param {*} res
+ * @param {*} dependencies
+ */
+async function handle(req, res, dependencies, owners) {
+  const owner = req.body.owner;
+  const repository = req.body.repository;
+  const eventID = req.body.eventID;
+
+  const events = await dependencies.cache.fetchRepoEvents(owner, repository);
+  let body = null;
+  let source = null;
+  for (let index = 0; index < events.length; index++) {
+    if (events[index].eventID === eventID) {
+      source = events[index].source;
+      body = events[index].body;
+    }
+  }
+
+  if (body != null) {
+    if (source === "pull-request") {
+      await pullRequestEvent.handle(body, eventID, dependencies);
+    } else if (source === "branch-push") {
+      await pushEvent.handle(body, eventID, dependencies);
+    } else if (source === "release") {
+      await releaseEvent.handle(body, eventID, dependencies);
+    }
+  }
+
+  res.render(dependencies.viewsPath + "admin/executeRepoEvent", {
+    owners: owners,
+    isAdmin: req.validAdminSession,
+    owner: req.body.owner,
+    repository: req.body.repository,
+  });
+}
+
+module.exports.path = path;
+module.exports.method = method;
+module.exports.handle = handle;

--- a/controllers/admin/viewRepoEventDetails.js
+++ b/controllers/admin/viewRepoEventDetails.js
@@ -21,10 +21,13 @@ function requiresAdmin() {
 async function handle(req, res, dependencies, owners) {
   const owner = req.query.owner;
   const repository = req.query.repository;
+  const eventID = req.query.eventID;
   const events = await dependencies.cache.fetchRepoEvents(owner, repository);
   let body = "";
-  if (req.query.index >= 0 && req.query.index < events.length) {
-    body = JSON.stringify(events[req.query.index].body, null, 2);
+  for (let index = 0; index < events.length; index++) {
+    if (events[index].eventID === eventID) {
+      body = JSON.stringify(events[index].body, null, 2);
+    }
   }
 
   res.render(dependencies.viewsPath + "admin/viewRepoEventDetails", {
@@ -32,6 +35,7 @@ async function handle(req, res, dependencies, owners) {
     isAdmin: req.validAdminSession,
     owner: owner,
     repository: repository,
+    eventID: eventID,
     body: body,
   });
 }

--- a/scm/events/pullRequest.js
+++ b/scm/events/pullRequest.js
@@ -8,9 +8,10 @@ const build = require("../../lib/build");
 /**
  * handle event
  * @param {*} body
+ * @param {*} eventID
  * @param {*} dependencies
  */
-async function handle(body, dependencies) {
+async function handle(body, eventID, dependencies) {
   // Parse the incoming body into the parts we care about
   const event = parseEvent(body);
   dependencies.logger.info("PullRequestEvent:");
@@ -22,6 +23,7 @@ async function handle(body, dependencies) {
   dependencies.cache.storeRepoEvent(event.owner, event.repo, {
     source: "pull-request",
     timestamp: new Date(),
+    eventID: eventID,
     body: body,
   });
   await dependencies.db.storeRepository(event.owner, event.repo);

--- a/scm/events/push.js
+++ b/scm/events/push.js
@@ -9,9 +9,10 @@ const notification = require("../../services/notification");
 /**
  * handle event
  * @param {*} body
+ * @param {*} eventID
  * @param {*} dependencies
  */
-async function handle(body, dependencies) {
+async function handle(body, eventID, dependencies) {
   // Parse the incoming body into the parts we care about
   const event = parseEvent(body);
   dependencies.logger.info("PushEvent:");
@@ -20,6 +21,7 @@ async function handle(body, dependencies) {
   dependencies.cache.storeRepoEvent(event.owner, event.repo, {
     source: "branch-push",
     timestamp: new Date(),
+    eventID: eventID,
     body: body,
   });
   await dependencies.db.storeRepository(event.owner, event.repo);

--- a/scm/events/release.js
+++ b/scm/events/release.js
@@ -8,10 +8,11 @@ const notification = require("../../services/notification");
 
 /**
  * handle event
- * @param {*} req
+ * @param {*} body
+ * @param {*} eventID
  * @param {*} dependencies
  */
-async function handle(body, dependencies) {
+async function handle(body, eventID, dependencies) {
   // Parse the incoming body into the parts we care about
   const event = parseEvent(body);
   dependencies.logger.info("ReleaseEvent:");
@@ -20,6 +21,7 @@ async function handle(body, dependencies) {
   dependencies.cache.storeRepoEvent(event.owner, event.repo, {
     source: "release",
     timestamp: new Date(),
+    eventID: eventID,
     body: body,
   });
   await dependencies.db.storeRepository(event.owner, event.repo);

--- a/views/admin/executeRepoEvent.pug
+++ b/views/admin/executeRepoEvent.pug
@@ -11,20 +11,11 @@ block content
 
 	+titleBar([{title: 'Repositories', href: '/admin/repositories'},
 	{title: owner + ' ' + repository, href: '/admin/repositoryAdmin?owner=' + owner + '&repository=' + repository},
-	{title: 'Repository SCM Events'}])
-		
+	{title: 'Repository SCM Events', href: '/admin/viewRepoEvents?owner=' + owner + '&repository=' + repository},
+	{title: 'Event Re-Execute'}])
+
 	div(class="flex flex-wrap m-4")
 	div(class="flex flex-wrap m-4")
 
-		table(class="table-auto w-full")
-			thead
-				tr
-					+tableHeader('Source')
-					+tableHeader('ID')
-					+tableHeader('Timestamp')
-			tbody
-				each event, i in events
-					+tableRow('/admin/viewRepoEventDetails?owner=' + owner + '&repository=' + repository + '&eventID=' + event.eventID)
-						+tableCell(event.source)
-						+tableCell(event.eventID)
-						+tableCell(event.timestamp)
+		p Event submitted for re-execution
+

--- a/views/admin/viewRepoEventDetails.pug
+++ b/views/admin/viewRepoEventDetails.pug
@@ -17,4 +17,12 @@ block content
 	div(class="flex flex-wrap m-4")
 	div(class="flex flex-wrap m-4")
 
+		form(class="w-full m-4" method="POST" action="/admin/executeRepoEvent")      
+			div(class="w-1/4 px-3 mb-6 md:mb-0")
+				button(class="bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded") Re-Execute Event
+				
+			+formHidden("owner", owner)
+			+formHidden("repository", repository)
+			+formHidden("eventID", eventID)
+
 		pre= body


### PR DESCRIPTION
This PR adds an Execute button to the scm event details screen. This can be used to re-execute an event for a particular repository. Note that this will create a new event in the history since it will be captured again by the system as it appears just like a normal event.

closes #677 
