### PR TITLE
✨Support for rendering Summary Table in UI and GitHub check

### DIFF
--- a/api/repository/taskDetails.js
+++ b/api/repository/taskDetails.js
@@ -25,6 +25,7 @@ async function handle(req, res, dependencies) {
   let configValues = [];
   let scmDetails = [];
   let summary = "";
+  let summaryTable = [];
   let text = "";
   let artifacts = [];
   if (detailsRows.rows.length > 0) {
@@ -50,7 +51,11 @@ async function handle(req, res, dependencies) {
       taskDetails.details.result.artifacts != null
         ? taskDetails.details.result.artifacts
         : [];
-
+    summaryTable =
+      taskDetails.details.result != null &&
+      taskDetails.details.result.summaryTable != null
+        ? taskDetails.details.result.summaryTable
+        : [];
     if (taskDetails.details.scm.pullRequest != null) {
       scmDetails.push({
         title: "PR Number",
@@ -105,13 +110,14 @@ async function handle(req, res, dependencies) {
     req.query.taskID
   );
   if (artifactRows != null && artifactRows.rows != null) {
-    artifacts = artifactRows.rows
+    artifacts = artifactRows.rows;
   }
-  
+
   res.send({
     task: task,
     configValues: configValues,
     summary: summary,
+    summaryTable: summaryTable,
     text: text,
     artifacts: artifacts,
     scmDetails: scmDetails,

--- a/controllers/history/taskDetails.js
+++ b/controllers/history/taskDetails.js
@@ -51,6 +51,11 @@ async function handle(req, res, dependencies, owners) {
       taskDetails.details.result.artifacts != null
         ? taskDetails.details.result.artifacts
         : [];
+    summaryTable =
+      taskDetails.details.result != null &&
+      taskDetails.details.result.summaryTable != null
+        ? taskDetails.details.result.summaryTable
+        : [];
 
     if (taskDetails.details.scm.pullRequest != null) {
       scmDetails.push({
@@ -125,6 +130,7 @@ async function handle(req, res, dependencies, owners) {
     taskDetails: taskDetails,
     configValues: configValues,
     summary: summary,
+    summaryTable: summaryTable,
     text: text,
     artifacts: artifacts,
     scmDetails: scmDetails,

--- a/controllers/monitor/buildTaskDetails.js
+++ b/controllers/monitor/buildTaskDetails.js
@@ -44,6 +44,11 @@ async function handle(req, res, dependencies, owners) {
       taskDetails.details.result.artifacts != null
         ? taskDetails.details.result.artifacts
         : [];
+    const summaryTable =
+      taskDetails.details.result != null &&
+      taskDetails.details.result.summaryTable != null
+        ? taskDetails.details.result.summaryTable
+        : [];
 
     const scmDetails = [];
     if (taskDetails.details.scm.pullRequest != null) {
@@ -112,6 +117,7 @@ async function handle(req, res, dependencies, owners) {
       taskDetails: taskDetails,
       configValues: configValues,
       summary: summary,
+      summaryTable: summaryTable,
       text: text,
       artifacts: artifacts,
       scmDetails: scmDetails,
@@ -125,6 +131,7 @@ async function handle(req, res, dependencies, owners) {
       taskDetails: { details: {} },
       configValues: [],
       summary: "",
+      summaryTable: summaryTable,
       text: "",
       artifacts: [],
       scmDetails: scmDetails,

--- a/controllers/repositories/taskDetails.js
+++ b/controllers/repositories/taskDetails.js
@@ -51,6 +51,11 @@ async function handle(req, res, dependencies, owners) {
       taskDetails.details.result.artifacts != null
         ? taskDetails.details.result.artifacts
         : [];
+    summaryTable =
+      taskDetails.details.result != null &&
+      taskDetails.details.result.summaryTable != null
+        ? taskDetails.details.result.summaryTable
+        : [];
 
     if (taskDetails.details.scm.pullRequest != null) {
       scmDetails.push({
@@ -125,6 +130,7 @@ async function handle(req, res, dependencies, owners) {
     taskDetails: taskDetails,
     configValues: configValues,
     summary: summary,
+    summaryTable: summaryTable,
     text: text,
     artifacts: artifacts,
     scmDetails: scmDetails,

--- a/lib/taskUpdate.js
+++ b/lib/taskUpdate.js
@@ -19,6 +19,8 @@ async function handle(job, serverConf, cache, scm, db, logger) {
     const taskID = event.taskID;
     let artifactList = "";
 
+    logger.verbose(JSON.stringify(event, null, 2));
+
     // Update task in the cache and send out notifications
     if (event.status === "completed") {
       event.stats.completedAt = new Date();
@@ -145,7 +147,11 @@ async function handle(job, serverConf, cache, scm, db, logger) {
       if (event.result.title != null) {
         update.output = {
           title: event.result.title,
-          summary: summaryWithArtifactList(event.result.summary, artifactList),
+          summary: summaryWithArtifactList(
+            event.result.summary,
+            event.result.summaryTable,
+            artifactList
+          ),
           text: event.result.text != null ? event.result.text : "",
         };
       }
@@ -157,12 +163,88 @@ async function handle(job, serverConf, cache, scm, db, logger) {
   }
 }
 
-function summaryWithArtifactList(summary, artifactList) {
+function summaryWithArtifactList(summary, summaryTable, artifactList) {
+  let result = "";
   if (summary != null) {
-    return summary + "\n" + artifactList;
-  } else {
-    return artifactList;
+    result += summary;
   }
+
+  if (summaryTable != null) {
+    result += "\n";
+    result += "| | |\n";
+    result += "| --- | --- |\n";
+    summaryTable.forEach((summary) => {
+      result += "\n";
+      result += "| ";
+      if (summary.link != null) {
+        result += '<a href="' + summary.link + '">';
+        result += summary.title;
+        result += "</a>";
+      } else {
+        result += summary.title;
+      }
+      result += " | ";
+      if (summary.valueString != null) {
+        result += summary.valueString;
+        result += " ";
+      }
+      if (summary.valueBadges != null) {
+        summary.valueBadges.forEach((badge) => {
+          if (summary.link != null) {
+            result += '<a href="' + summary.link + '">';
+          }
+          if (badge.logo != null && badge.style != null) {
+            result +=
+              'img(src="https://img.shields.io/badge/' +
+              badge.shield +
+              "?logo=" +
+              badge.logo +
+              "&style=" +
+              badge.style +
+              '" alt="' +
+              badge.alt +
+              '"/>';
+          } else if (badge.logo != null) {
+            result +=
+              'img(src="https://img.shields.io/badge/' +
+              badge.shield +
+              "?logo=" +
+              badge.logo +
+              '" alt="' +
+              badge.alt +
+              '"/>';
+          } else if (badge.style != null) {
+            result +=
+              'img(src="https://img.shields.io/badge/' +
+              badge.shield +
+              "?style=" +
+              badge.style +
+              '" alt="' +
+              badge.alt +
+              '"/>';
+          } else {
+            result +=
+              'img(src="https://img.shields.io/badge/' +
+              badge.shield +
+              '" alt="' +
+              badge.alt +
+              '"/>';
+          }
+          if (summary.link != null) {
+            result += "</a>";
+          }
+          result += " ";
+        });
+      }
+      result += " | \n";
+    });
+  }
+
+  if (artifactList != null) {
+    result += "\n\n";
+    result += artifactList;
+  }
+  return result;
 }
 
 module.exports.handle = handle;

--- a/views/components/resultSummary.pug
+++ b/views/components/resultSummary.pug
@@ -1,0 +1,32 @@
+mixin resultSummary(summary, summaryTable)
+    +infoCard('Summary')
+        div(id="task-result-summary")
+        data(id="task-result-summary-data" hidden)
+            = summary
+        script.
+            document.getElementById('task-result-summary').innerHTML =
+            marked(document.getElementById('task-result-summary-data').innerHTML, {gfm: true});
+
+        if summaryTable.length > 0
+            br
+            hr
+            div
+                table(class="table-auto w-full")
+                    tbody
+                        each summary, i in summaryTable
+                            +tableRow(summary.link)
+                                +tableCell(summary.title)
+                                td(class="border px-2 py-2")
+                                    div(class="flex space-x-4")
+                                        if summary.valueString != null
+                                            div= summary.valueString
+                                        if summary.valueBadges != null 
+                                            each badge, b in summary.valueBadges
+                                                if badge.logo && badge.style
+                                                    img(src=`https://img.shields.io/badge/` + badge.shield + `?logo=` + badge.logo + `&style=` + badge.style alt=`` + badge.alt)
+                                                else if badge.logo
+                                                    img(src=`https://img.shields.io/badge/` + badge.shield + `?logo=` + badge.logo alt=`` + badge.alt)
+                                                else if badge.style 
+                                                    img(src=`https://img.shields.io/badge/` + badge.shield + `?style=` + badge.style alt=`` + badge.alt)
+                                                else
+                                                    img(src=`https://img.shields.io/badge/` + badge.shield alt=`` + badge.alt)

--- a/views/history/buildTaskDetails.pug
+++ b/views/history/buildTaskDetails.pug
@@ -6,6 +6,7 @@ include ../components/tableRow
 include ../components/infoCard
 include ../components/tableCellButton
 include ../components/tableConclusionCell
+include ../components/resultSummary
 
 block content
 
@@ -93,13 +94,7 @@ block content
                           else
                             +tableCellButton("View", artifact.url)
         
-        +infoCard('Summary')
-          div(id="task-result-summary")
-          data(id="task-result-summary-data" hidden)
-            = taskDetails.details.result.summary
-          script.
-            document.getElementById('task-result-summary').innerHTML =
-              marked(document.getElementById('task-result-summary-data').innerHTML, {gfm: true});
+        +resultSummary(taskDetails.details.result.summary, taskDetails.details.result.summaryTable)
 
         +infoCard('Text')
           div(id="task-result-text")

--- a/views/history/taskDetails.pug
+++ b/views/history/taskDetails.pug
@@ -6,6 +6,7 @@ include ../components/tableConclusionCell
 include ../components/tableRow
 include ../components/infoCard
 include ../components/tableCellButton
+include ../components/resultSummary
 
 block content
 
@@ -109,14 +110,8 @@ block content
                             +tableCellButton("Install", artifact.url)
                           else
                             +tableCellButton("View", artifact.url)
-
-        +infoCard('Summary')
-          div(id="task-result-summary")
-          data(id="task-result-summary-data" hidden)
-            = summary
-          script.
-            document.getElementById('task-result-summary').innerHTML =
-              marked(document.getElementById('task-result-summary-data').innerHTML, {gfm: true});
+        
+        +resultSummary(summary, summaryTable)
 
         +infoCard('Text')
           div(id="task-result-text")

--- a/views/monitor/buildTaskDetails.pug
+++ b/views/monitor/buildTaskDetails.pug
@@ -6,6 +6,7 @@ include ../components/tableRow
 include ../components/infoCard
 include ../components/tableCellButton
 include ../components/tableConclusionCell
+include ../components/resultSummary
 
 block content
 
@@ -78,13 +79,7 @@ block content
                           else
                             +tableCellButton("View", artifact.url)
                             
-        +infoCard('Summary')
-          div(id="task-result-summary")
-          data(id="task-result-summary-data" hidden)
-            = summary
-          script.
-            document.getElementById('task-result-summary').innerHTML =
-              marked(document.getElementById('task-result-summary-data').innerHTML, {gfm: true});
+        +resultSummary(summary, summaryTable)
 
         +infoCard('Text')
           div(id="task-result-text")

--- a/views/repositories/taskDetails.pug
+++ b/views/repositories/taskDetails.pug
@@ -6,6 +6,7 @@ include ../components/tableRow
 include ../components/infoCard
 include ../components/tableCellButton
 include ../components/tableConclusionCell
+include ../components/resultSummary
 
 block content
 
@@ -91,13 +92,7 @@ block content
                           else
                             +tableCellButton("View", artifact.url)
 
-        +infoCard('Summary')
-          div(id="task-result-summary")
-          data(id="task-result-summary-data" hidden)
-            = summary
-          script.
-            document.getElementById('task-result-summary').innerHTML =
-              marked(document.getElementById('task-result-summary-data').innerHTML, {gfm: true});
+        +resultSummary(summary, summaryTable)
 
         +infoCard('Text')
           div(id="task-result-text" class="overflow-scroll")


### PR DESCRIPTION
This PR adds support for rendering the new `summaryTable` task result. This is supported in the latest stampede-worker version and allows for displaying tabular data in the summary without having to create the markdown directly. Adding native table support makes this look better in the UI and also will improve how it looks in the mobile app. Support for `shields.io` badges inside the table also further improve how the summary looks.

Using the summaryTable can be an alternate to the markdown summary, or can be used together with it. See the stampede-worker release for details on how to format the stampede table json so it will be rendered correctly.

closes #682 