### PR TITLE
✨ New config option to disable artifact list auto rendering

### DIFF
--- a/bin/stampede-server.js
+++ b/bin/stampede-server.js
@@ -91,6 +91,8 @@ const conf = require("rc")("stampede", {
   workerHeartbeatTimeout: 3600,
   // Repository event cache limit
   repoEventLimit: 10,
+  // Render artifact list automatically in PR comment, slack notification and GitHub check summary
+  autoRenderArtifactListComment: "enabled",
 });
 
 // Configure winston logging

--- a/lib/notificationChannels/prComment.js
+++ b/lib/notificationChannels/prComment.js
@@ -155,7 +155,10 @@ async function prepareBuildCompletedNotification(notification, dependencies) {
       }
     }
 
-    if (artifactList != "") {
+    if (
+      artifactList != "" &&
+      dependencies.serverConfig.autoRenderArtifactListComment === "enabled"
+    ) {
       message += "*Artifacts*:\n" + artifactList + "\n\n";
     }
 

--- a/lib/notificationChannels/slack.js
+++ b/lib/notificationChannels/slack.js
@@ -185,7 +185,10 @@ async function prepareBuildCompletedNotification(notification, dependencies) {
       }
     }
 
-    if (artifactList != "") {
+    if (
+      artifactList != "" &&
+      dependencies.serverConfig.autoRenderArtifactListComment === "enabled"
+    ) {
       message += "*Artifacts*:\n" + artifactList + "\n\n";
     }
   }

--- a/lib/taskUpdate.js
+++ b/lib/taskUpdate.js
@@ -150,7 +150,8 @@ async function handle(job, serverConf, cache, scm, db, logger) {
           summary: summaryWithArtifactList(
             event.result.summary,
             event.result.summaryTable,
-            artifactList
+            artifactList,
+            serverConf
           ),
           text: event.result.text != null ? event.result.text : "",
         };
@@ -163,7 +164,12 @@ async function handle(job, serverConf, cache, scm, db, logger) {
   }
 }
 
-function summaryWithArtifactList(summary, summaryTable, artifactList) {
+function summaryWithArtifactList(
+  summary,
+  summaryTable,
+  artifactList,
+  serverConf
+) {
   let result = "";
   if (summary != null) {
     result += summary;
@@ -240,7 +246,10 @@ function summaryWithArtifactList(summary, summaryTable, artifactList) {
     });
   }
 
-  if (artifactList != null) {
+  if (
+    artifactList != null &&
+    serverConf.autoRenderArtifactListComment === "enabled"
+  ) {
     result += "\n\n";
     result += artifactList;
   }


### PR DESCRIPTION
This PR adds a new config option: `autoRenderArtifactListComment` which disables the automatic rendering of the artifact list links in GitHub check summaries, PR comments and Slack notifications. The default is still enabled so existing installations will continue to work as configured. But for cases where are more streamlined summary is desired, this can be disabled and then you can optionally include the links to the artifacts desired in the summary or summaryTable itself.

closes #684 
