### PR TITLE
✨ Now supporting streamlined summary table in pr comment

### DIFF
--- a/lib/notificationChannels/prComment.js
+++ b/lib/notificationChannels/prComment.js
@@ -79,6 +79,7 @@ async function prepareBuildCompletedNotification(notification, dependencies) {
       taskResultDetails.details.result.summary != null
     ) {
       task.summary = taskResultDetails.details.result.summary;
+      task.summaryTable = taskResultDetails.details.result.summaryTable;
     }
     tasks.push(task);
 
@@ -124,52 +125,34 @@ async function prepareBuildCompletedNotification(notification, dependencies) {
     }
   }
 
+  let message = "";
   if (failedTasks == true) {
-    let message = ":scream: Oh no! Some of the stampede tasks have failed:\n\n";
-
-    for (let index = 0; index < tasks.length; index++) {
-      if (tasks[index].conclusion == "failure") {
-        message += "- :x: " + tasks[index].title + "\n";
-      } else {
-        message += "- :white_check_mark: " + tasks[index].title + "\n";
-      }
+    if (notificationStyle(notification) === "summaryTable") {
+      message = failedTasksMessageSummaryTable(notification, tasks);
+    } else {
+      message = failedTasksMessageSummary(notification, tasks);
     }
-
-    message += "\n";
-    message +=
-      "[More Info...](" +
-      moreInfoURL +
-      "/repositories/buildDetails?buildID=" +
-      notification.build +
-      ")";
-
-    return message;
   } else {
-    let message =
-      ":racehorse: Sweet! All your stampede tasks have passed...\n\n";
-
-    for (let index = 0; index < tasks.length; index++) {
-      if (tasks[index].summary != null) {
-        message += "*" + tasks[index].title + "*:\n";
-        message += tasks[index].summary + "\n\n";
-      }
+    if (notificationStyle(notification) === "summaryTable") {
+      message = successTasksMessageSummaryTable(notification, tasks);
+    } else {
+      message = successTasksMessageSummary(notification, tasks);
     }
-
     if (
       artifactList != "" &&
       dependencies.serverConfig.autoRenderArtifactListComment === "enabled"
     ) {
-      message += "*Artifacts*:\n" + artifactList + "\n\n";
+      message += "\n*Artifacts*:\n" + artifactList + "\n\n";
     }
-
-    message +=
-      "[More Info...](" +
-      moreInfoURL +
-      "/repositories/buildDetails?buildID=" +
-      notification.build +
-      ")";
-    return message;
   }
+
+  message +=
+    "\n[More Info...](" +
+    moreInfoURL +
+    "/repositories/buildDetails?buildID=" +
+    notification.build +
+    ")";
+  return message;
 }
 
 async function sendNotificationToPRComment(
@@ -214,6 +197,143 @@ async function matchesFilter(notification, dependencies) {
   } else {
     return false;
   }
+}
+
+function notificationStyle(notification) {
+  if (
+    notification.channelConfig != null &&
+    notification.channelConfig.config != null &&
+    notification.channelConfig.config.style != null
+  ) {
+    return notification.channelConfig.config.style;
+  } else {
+    return "summary";
+  }
+}
+
+function failedTasksMessageSummary(notification, tasks) {
+  let message = ":scream: Oh no! Some of the stampede tasks have failed:\n\n";
+
+  for (let index = 0; index < tasks.length; index++) {
+    if (tasks[index].conclusion == "failure") {
+      message += "- :x: " + tasks[index].title + "\n";
+    } else {
+      message += "- :white_check_mark: " + tasks[index].title + "\n";
+    }
+  }
+  return message;
+}
+
+function failedTasksMessageSummaryTable(notification, tasks) {
+  let message = ":scream: Oh no! Some of the stampede tasks have failed:\n\n";
+
+  message += "| | |\n";
+  message += "| --- | --- |\n";
+
+  for (let index = 0; index < tasks.length; index++) {
+    if (tasks[index].conclusion == "failure") {
+      message += "| " + tasks[index].title + " | :x: Failure |\n";
+    } else {
+      message +=
+        "| " + tasks[index].title + " | :white_check_mark: Success |\n";
+    }
+  }
+  return message;
+}
+
+function successTasksMessageSummary(notification, tasks) {
+  let message = ":racehorse: Sweet! All your stampede tasks have passed...\n\n";
+
+  for (let index = 0; index < tasks.length; index++) {
+    if (tasks[index].summary != null) {
+      message += "*" + tasks[index].title + "*:\n";
+      message += tasks[index].summary + "\n\n";
+    }
+  }
+  return message;
+}
+
+function successTasksMessageSummaryTable(notification, tasks) {
+  let message = ":racehorse: Sweet! All your stampede tasks have passed...\n\n";
+
+  message += "| | |\n";
+  message += "| --- | --- |\n";
+
+  for (let index = 0; index < tasks.length; index++) {
+    if (
+      tasks[index].summaryTable != null &&
+      tasks[index].summaryTable.length > 0
+    ) {
+      tasks[index].summaryTable.forEach((summary) => {
+        message += "| ";
+        if (summary.link != null) {
+          message += '<a href="' + summary.link + '">';
+          message += summary.title;
+          message += "</a>";
+        } else {
+          message += summary.title;
+        }
+        message += " | ";
+        if (summary.valueString != null) {
+          message += summary.valueString;
+          message += " ";
+        }
+        if (summary.valueBadges != null) {
+          summary.valueBadges.forEach((badge) => {
+            if (summary.link != null) {
+              message += '<a href="' + summary.link + '">';
+            }
+            if (badge.logo != null && badge.style != null) {
+              message +=
+                '<img src="https://img.shields.io/badge/' +
+                badge.shield +
+                "?logo=" +
+                badge.logo +
+                "&style=" +
+                badge.style +
+                '" alt="' +
+                badge.alt +
+                '"/>';
+            } else if (badge.logo != null) {
+              message +=
+                '<img src="https://img.shields.io/badge/' +
+                badge.shield +
+                "?logo=" +
+                badge.logo +
+                '" alt="' +
+                badge.alt +
+                '"/>';
+            } else if (badge.style != null) {
+              message +=
+                '<img src="https://img.shields.io/badge/' +
+                badge.shield +
+                "?style=" +
+                badge.style +
+                '" alt="' +
+                badge.alt +
+                '"/>';
+            } else {
+              message +=
+                '<img src="https://img.shields.io/badge/' +
+                badge.shield +
+                '" alt="' +
+                badge.alt +
+                '"/>';
+            }
+            if (summary.link != null) {
+              message += "</a>";
+            }
+            message += " ";
+          });
+        }
+        message += " | \n";
+      });
+    } else {
+      message +=
+        "| " + tasks[index].title + " | :white_check_mark: Success |\n";
+    }
+  }
+  return message;
 }
 
 module.exports.sendNotification = sendNotification;

--- a/lib/notificationChannels/slack.js
+++ b/lib/notificationChannels/slack.js
@@ -100,6 +100,7 @@ async function prepareBuildCompletedNotification(notification, dependencies) {
       taskResultDetails.details.result.summary != null
     ) {
       task.summary = taskResultDetails.details.result.summary;
+      task.summaryTable = taskResultDetails.details.result.summaryTable;
     }
     tasks.push(task);
 
@@ -144,72 +145,42 @@ async function prepareBuildCompletedNotification(notification, dependencies) {
     }
   }
 
-  let message = "";
+  let blocks = [];
   if (failedTasks == true) {
-    message =
-      "@channel :scream: Oh no! Some of the stampede tasks have failed for build " +
-      notification.payload.owner +
-      "/" +
-      notification.payload.repo +
-      " " +
-      notification.payload.buildKey +
-      " #" +
-      notification.payload.buildNumber +
-      ":\n\n";
-
-    for (let index = 0; index < tasks.length; index++) {
-      if (tasks[index].conclusion == "failure") {
-        message += "- :x: " + tasks[index].title + "\n";
-      } else {
-        message += "- :white_check_mark: " + tasks[index].title + "\n";
-      }
-    }
-
-    message += "\n";
+    blocks.push(...failedTasksMessageSummary(notification, tasks));
   } else {
-    message =
-      ":racehorse: *Build completed successfully!* " +
-      notification.payload.owner +
-      "/" +
-      notification.payload.repo +
-      " " +
-      notification.payload.buildKey +
-      " #" +
-      notification.payload.buildNumber +
-      "\n\n";
-
-    for (let index = 0; index < tasks.length; index++) {
-      if (tasks[index].summary != null) {
-        message += "*" + tasks[index].title + "*:\n";
-        message += tasks[index].summary + "\n\n";
-      }
-    }
-
-    if (
-      artifactList != "" &&
-      dependencies.serverConfig.autoRenderArtifactListComment === "enabled"
-    ) {
-      message += "*Artifacts*:\n" + artifactList + "\n\n";
-    }
+    let summaryBlocks = successTasksMessageSummary(notification, tasks);
+    blocks.push(...successTasksMessageSummary(notification, tasks));
   }
 
-  return {
-    blocks: [
-      {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text:
-            message +
-            " " +
-            "*<" +
-            moreInfoURL +
-            "/repositories/buildDetails?buildID=" +
-            notification.build +
-            "|More info...>* ",
-        },
+  if (
+    artifactList != "" &&
+    dependencies.serverConfig.autoRenderArtifactListComment === "enabled"
+  ) {
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "*Artifacts*:\n" + artifactList,
       },
-    ],
+    });
+  }
+
+  blocks.push({
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text:
+        "*<" +
+        moreInfoURL +
+        "/repositories/buildDetails?buildID=" +
+        notification.build +
+        "|More info...>* ",
+    },
+  });
+
+  return {
+    blocks: blocks,
   };
 }
 
@@ -257,6 +228,80 @@ async function matchesFilter(notification, dependencies) {
   } else {
     return false;
   }
+}
+
+function failedTasksMessageSummary(notification, tasks) {
+  let blocks = [];
+  blocks.push({
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text:
+        "@channel :scream: Oh no! Some of the stampede tasks have failed for build " +
+        notification.payload.owner +
+        "/" +
+        notification.payload.repo +
+        " " +
+        notification.payload.buildKey +
+        " #" +
+        notification.payload.buildNumber +
+        ":\n\n",
+    },
+  });
+
+  for (let index = 0; index < tasks.length; index++) {
+    if (tasks[index].conclusion == "failure") {
+      blocks.push({
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: ":x: " + tasks[index].title,
+        },
+      });
+    } else {
+      blocks.push({
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: ":white_check_mark: " + tasks[index].title,
+        },
+      });
+    }
+  }
+
+  return blocks;
+}
+
+function successTasksMessageSummary(notification, tasks) {
+  let blocks = [];
+  blocks.push({
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text:
+        ":racehorse: *Build completed successfully!* " +
+        notification.payload.owner +
+        "/" +
+        notification.payload.repo +
+        " " +
+        notification.payload.buildKey +
+        " #" +
+        notification.payload.buildNumber +
+        ":\n\n",
+    },
+  });
+
+  for (let index = 0; index < tasks.length; index++) {
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: ":white_check_mark: " + tasks[index].title,
+      },
+    });
+  }
+
+  return blocks;
 }
 
 module.exports.sendNotification = sendNotification;

--- a/scm/testMode.js
+++ b/scm/testMode.js
@@ -136,7 +136,6 @@ async function commentOnPR(owner, repository, prNumber, comment, serverConfig) {
   systemLogger.info(`repository: ${repository}`);
   systemLogger.info(`prNumber: ${prNumber}`);
   systemLogger.info(`comment: ${comment}`);
-  console.log(comment);
 }
 
 module.exports.verifyCredentials = verifyCredentials;


### PR DESCRIPTION
This PR adds the streamlined summary table as a style option for the PR Comment. To enable this, just add `style: summaryTable` to the channel config for the PR comment notification channel. When enabled, the output will be a table format instead of the possibly more verbose summary text.

This PR also adjusts the Slack output slightly to make it more streamlined. Slack doesn't support using badge images very well, so instead of supporting the summary table it only supports this new more streamlined mode.

closes #683 
