### PR TITLE
🐛 Only render markdown table if summary table has rows

### DIFF
--- a/lib/taskUpdate.js
+++ b/lib/taskUpdate.js
@@ -175,7 +175,7 @@ function summaryWithArtifactList(
     result += summary;
   }
 
-  if (summaryTable != null) {
+  if (summaryTable != null && summaryTable.length > 0) {
     result += "\n\n";
     result += "| | |\n";
     result += "| --- | --- |\n";


### PR DESCRIPTION
This PR fixes a minor rendering glitch in the GitHub checks if a task doesn't have any summary table information. Previously it would render the table header but because there are no rows, GitHub would display two small boxes for that table. This PR removes the table completely in these cases.

closes #692 
