### PR TITLE
✨ Now capturing yaml parse errors in stampede config files

### DIFF
--- a/bin/stampede-server.js
+++ b/bin/stampede-server.js
@@ -91,6 +91,9 @@ const conf = require("rc")("stampede", {
   workerHeartbeatTimeout: 3600,
   // Repository event cache limit
   repoEventLimit: 10,
+  // Repository parse error limit and timeout
+  repoParseErrorLimit: 10,
+  repoParseErrorTimeout: 14400,
   // Render artifact list automatically in PR comment, slack notification and GitHub check summary
   autoRenderArtifactListComment: "enabled",
 });

--- a/controllers/admin/viewRepoParseErrors.js
+++ b/controllers/admin/viewRepoParseErrors.js
@@ -1,0 +1,41 @@
+/**
+ * path this handler will serve
+ */
+function path() {
+  return "/admin/viewRepoParseErrors";
+}
+
+/**
+ * if the route requires admin
+ */
+function requiresAdmin() {
+  return true;
+}
+
+/**
+ * handle index
+ * @param {*} req
+ * @param {*} res
+ * @param {*} dependencies
+ */
+async function handle(req, res, dependencies, owners) {
+  const owner = req.query.owner;
+  const repository = req.query.repository;
+  const errors = await dependencies.cache.fetchRepoParseErrors(
+    owner,
+    repository
+  );
+  console.dir(errors);
+
+  res.render(dependencies.viewsPath + "admin/viewRepoParseErrors", {
+    owners: owners,
+    isAdmin: req.validAdminSession,
+    owner: owner,
+    repository: repository,
+    errors: errors,
+  });
+}
+
+module.exports.path = path;
+module.exports.requiresAdmin = requiresAdmin;
+module.exports.handle = handle;

--- a/lib/cache/cache.js
+++ b/lib/cache/cache.js
@@ -14,6 +14,8 @@ const notifications = require("./notifications");
 
 let workerHeartbeatTimeout = 35;
 let repoEventLimit = 10;
+let repoParseErrorLimit = 10;
+let repoParseErrorTimeout = 14400;
 
 // Public functions
 
@@ -35,6 +37,8 @@ function startCache(conf) {
   notifications.setClient(client);
   workerHeartbeatTimeout = conf.workerHeartbeatTimeout;
   repoEventLimit = conf.repoEventLimit;
+  repoParseErrorLimit = conf.repoParseErrorLimit;
+  repoParseErrorTimeout = conf.repoParseErrorTimeout;
 }
 
 /**
@@ -421,6 +425,39 @@ async function fetchRepoEvents(owner, repo) {
   return events;
 }
 
+/**
+ * storeRepoParseError
+ * @param {*} owner
+ * @param {*} repo
+ * @param {*} error
+ */
+async function storeRepoParseError(owner, repo, error) {
+  // Ignore if our repoEventLimit is 0
+  if (repoParseErrorLimit > 0) {
+    await client.pushItem(
+      "stampede-" + owner + "-" + repo + "-parseErrors",
+      error,
+      repoParseErrorLimit
+    );
+    await client.expireItem(
+      "stampede-" + owner + "-" + repo + "-parseErrors",
+      repoParseErrorTimeout
+    );
+  }
+}
+
+/**
+ * fetchRepoParseErrors
+ * @param {*} owner
+ * @param {*} repo
+ */
+async function fetchRepoParseErrors(owner, repo) {
+  const errors = await client.fetchItems(
+    "stampede-" + owner + "-" + repo + "-parseErrors"
+  );
+  return errors;
+}
+
 // Private functions
 
 // General
@@ -488,3 +525,7 @@ module.exports.notifications = notifications;
 // Events
 module.exports.storeRepoEvent = storeRepoEvent;
 module.exports.fetchRepoEvents = fetchRepoEvents;
+
+// Parse Errors
+module.exports.storeRepoParseError = storeRepoParseError;
+module.exports.fetchRepoParseErrors = fetchRepoParseErrors;

--- a/lib/cache/cacheClient.js
+++ b/lib/cache/cacheClient.js
@@ -200,6 +200,20 @@ async function fetchItems(key) {
 }
 
 /**
+ * expireItem
+ * Set the expiration on a single item
+ * @param {*} key
+ * @param {*} expire
+ */
+async function expireItem(key, expire) {
+  try {
+    await client.expire(key, expire);
+  } catch (e) {
+    console.error("Error trying to expire item: " + key + " " + e);
+  }
+}
+
+/**
  * quit
  */
 async function quit() {
@@ -217,3 +231,4 @@ module.exports.fetchMembers = fetchMembers;
 module.exports.quit = quit;
 module.exports.pushItem = pushItem;
 module.exports.fetchItems = fetchItems;
+module.exports.expireItem = expireItem;

--- a/lib/config.js
+++ b/lib/config.js
@@ -31,6 +31,18 @@ async function findRepoConfig(
       sha,
       serverConf
     );
+    if (config.error != null) {
+      let storedError = {
+        error: config.error,
+        timestamp: new Date(),
+      };
+      cache.storeRepoParseError(owner, repo, storedError);
+      return null;
+    } else if (config.config != null) {
+      return config.config;
+    } else {
+      return null;
+    }
   }
   return config;
 }

--- a/scm/github.js
+++ b/scm/github.js
@@ -151,17 +151,19 @@ async function findRepoConfig(owner, repo, stampedeFile, sha, serverConf) {
         try {
           const stampedeConfig = yaml.safeLoad(configFile.body);
           if (stampedeConfig != null) {
-            return stampedeConfig;
+            return {
+              config: stampedeConfig,
+            };
           }
         } catch (e) {
-          return {};
+          return { error: e };
         }
       }
     }
     return null;
   } catch (e) {
     systemLogger.verbose("exception trying to find config: " + e);
-    return null;
+    return { error: e };
   }
 }
 

--- a/scm/testMode.js
+++ b/scm/testMode.js
@@ -33,9 +33,9 @@ async function findRepoConfig(owner, repo, stampedeFile, sha, serverConf) {
       systemLogger.verbose("loading repo config: " + path);
       const testModeConfigFile = fs.readFileSync(path);
       const config = yaml.safeLoad(testModeConfigFile);
-      return config;
+      return { config: config };
     } catch (e) {
-      return {};
+      return { error: e };
     }
   } else {
     return null;

--- a/views/admin/repositoryAdmin.pug
+++ b/views/admin/repositoryAdmin.pug
@@ -52,6 +52,10 @@ block content
                 +tableCell('SCM Events')
                 +tableCell('')
                 +tableCellButton("View", `/admin/viewRepoEvents?owner=` + owner + `&repository=` + repository)
+              +tableRow()
+                +tableCell('Parse Errors')
+                +tableCell('')
+                +tableCellButton("View", `/admin/viewRepoParseErrors?owner=` + owner + `&repository=` + repository)
 
   div(class="w-full p-3")
       div(class="bg-white border-transparent rounded-lg shadow-lg")

--- a/views/admin/viewRepoParseErrors.pug
+++ b/views/admin/viewRepoParseErrors.pug
@@ -1,0 +1,26 @@
+extends ../layout
+
+include ../components/titleBar
+include ../components/tableHeader
+include ../components/tableCell
+include ../components/tableRow
+include ../components/formFile
+include ../components/formHidden
+
+block content
+
+    +titleBar([{title: 'Repositories', href: '/admin/repositories'},
+    {title: owner + ' ' + repository, href: '/admin/repositoryAdmin?owner=' + owner + '&repository=' + repository},
+    {title: 'Repository Config Parse Errors'}])
+
+    div(class="flex flex-wrap m-4")
+    div(class="flex flex-wrap m-4")
+
+        each error, i in errors
+            div(class="")
+                p= error.timestamp + ` ` + error.error.name
+                br
+                p= error.error.reason
+                br
+                pre= error.error.message
+                br


### PR DESCRIPTION
This PR adds capturing for YAML parse errors when the system is trying to parse a repositories stampede.yaml file. Before there was little indication of any problem, only that nothing worked. While there was some logging in the server, it was hard to isolate. So now the server stores these errors for a limited amount of time. You can find them in the Admin Repository details screen.

closes #566 
